### PR TITLE
ラジオ局削除API実装

### DIFF
--- a/app/DataProviders/Repositories/RadioStationRepository.php
+++ b/app/DataProviders/Repositories/RadioStationRepository.php
@@ -73,4 +73,16 @@ class RadioStationRepository
         $radio_station->name = $request->name;
         return $radio_station->save();
     }
+
+    /**
+     * ラジオ局削除
+     *
+     * @param int $radio_station_id ラジオ局ID
+     * @return int 削除した件数
+     */
+    public function deleteRadioStation(int $radio_station_id): int
+    {
+        $radio_station = $this->radio_station::find($radio_station_id);
+        return $radio_station->delete();
+    }
 }

--- a/app/Http/Controllers/RadioStationController.php
+++ b/app/Http/Controllers/RadioStationController.php
@@ -78,13 +78,22 @@ class RadioStationController extends Controller
     }
 
     /**
-     * Remove the specified resource from storage.
+     * ラジオ局削除（1局のみ）
      *
-     * @param  int  $id
+     * @param int $radio_station_id ラジオ局ID
      * @return \Illuminate\Http\Response
      */
-    public function destroy($id)
+    public function destroy(int $radio_station_id)
     {
-        //
+        $radio_stations_destroy_count = $this->radio_station->deleteRadioStation($radio_station_id);
+        if ($radio_stations_destroy_count == 1) {
+            return response()->json([
+                'message' => 'ラジオ局が削除されました。'
+            ], 200, [], JSON_UNESCAPED_UNICODE);
+        } else {
+            return response()->json([
+                'message' => 'ラジオ局の削除に失敗しました。'
+            ], 409, [], JSON_UNESCAPED_UNICODE);
+        }
     }
 }

--- a/app/Http/Controllers/RadioStationController.php
+++ b/app/Http/Controllers/RadioStationController.php
@@ -94,7 +94,7 @@ class RadioStationController extends Controller
         } else {
             return response()->json([
                 'message' => 'ラジオ局の削除に失敗しました。'
-            ], 409, [], JSON_UNESCAPED_UNICODE);
+            ], 500, [], JSON_UNESCAPED_UNICODE);
         }
     }
 }

--- a/app/Http/Controllers/RadioStationController.php
+++ b/app/Http/Controllers/RadioStationController.php
@@ -86,6 +86,7 @@ class RadioStationController extends Controller
     public function destroy(int $radio_station_id)
     {
         $radio_stations_destroy_count = $this->radio_station->deleteRadioStation($radio_station_id);
+        // TODO: 分岐の条件検討する
         if ($radio_stations_destroy_count == 1) {
             return response()->json([
                 'message' => 'ラジオ局が削除されました。'

--- a/app/Services/Radio/RadioStationService.php
+++ b/app/Services/Radio/RadioStationService.php
@@ -74,4 +74,16 @@ class RadioStationService
         $radio_station = $this->radio_station->updateRadioStation($request, $radio_station_id);
         return $radio_station;
     }
+
+    /**
+     * ラジオ局削除
+     *
+     * @param int $radio_station_id ラジオ局ID
+     * @return int 削除した件数
+     */
+    public function deleteRadioStation(int $radio_station_id): int
+    {
+        $radio_stations_destroy_count = $this->radio_station->deleteRadioStation($radio_station_id);
+        return $radio_stations_destroy_count;
+    }
 }

--- a/tests/Feature/RadioStationTest.php
+++ b/tests/Feature/RadioStationTest.php
@@ -127,4 +127,23 @@ class RadioStationTest extends TestCase
         $radio_station = RadioStation::first();
         $this->assertEquals('テスト局1', $radio_station->name);
     }
+
+    /**
+     * @test
+     * App\Http\Controllers\RadioStationController@destroy
+     */
+    public function ラジオ局を削除できる()
+    {
+        $this->postJson('api/radio_stations', ['name' => 'テスト局1']);
+        $radio_station = RadioStation::first();
+
+        $response = $this->deleteJson('api/radio_stations/' . $radio_station->id);
+
+        $response->assertStatus(200)
+            ->assertJson([
+                'message' => 'ラジオ局が削除されました。'
+            ]);
+
+        $this->assertEquals(0, RadioStation::count());
+    }
 }


### PR DESCRIPTION
## チケットへのリンク

- https://trello.com/c/W1zOlNtZ/99-%E3%80%90api%E3%80%91%E3%83%A9%E3%82%B8%E3%82%AA%E5%B1%80%E5%89%8A%E9%99%A4api%E5%AE%9F%E8%A3%85

## やったこと

- ラジオ局削除APIの実装

## やらないこと

## できるようになること

- ラジオ局を削除できるようになる
- 削除は1リクエストにつき1局のみ

## できなくなること

## 動作確認有無

- postmanにて動作確認済み

## 参考URL

## その他