### PR TITLE
ラジオ番組一覧取得APIの実装

### DIFF
--- a/app/DataProviders/Repositories/RadioProgramRepository.php
+++ b/app/DataProviders/Repositories/RadioProgramRepository.php
@@ -40,13 +40,14 @@ class RadioProgramRepository
     }
 
     /**
-     * ラジオ番組一覧取得
+     * ラジオ局に紐づいたラジオ番組一覧取得
      * 
+     * @param int $radio_station_id ラジオ局ID
      * @return object ラジオ番組一覧
      */
-    public function getAllRadioPrograms(): object
+    public function getAllRadioPrograms(int $radio_station_id): object
     {
-        return $this->radio_program::get();
+        return $this->radio_program::where('radio_station_id', $radio_station_id)->get();
     }
 
     /**

--- a/app/DataProviders/Repositories/RadioProgramRepository.php
+++ b/app/DataProviders/Repositories/RadioProgramRepository.php
@@ -40,6 +40,16 @@ class RadioProgramRepository
     }
 
     /**
+     * ラジオ番組一覧取得
+     * 
+     * @return object ラジオ番組一覧
+     */
+    public function getAllRadioPrograms(): object
+    {
+        return $this->radio_program::get();
+    }
+
+    /**
      * ラジオ番組作成
      *
      * @param RadioProgramRequest $request ラジオ番組作成リクエストデータ

--- a/app/Http/Controllers/RadioProgramController.php
+++ b/app/Http/Controllers/RadioProgramController.php
@@ -19,13 +19,15 @@ class RadioProgramController extends Controller
     }
 
     /**
-     * ラジオ番組一覧取得
+     * ラジオ局に紐づいたラジオ番組一覧取得
      *
+     * @param Request $request ラジオ局ID用のgetパラメーター
      * @return \Illuminate\Http\Response
      */
-    public function index()
+    public function index(Request $request)
     {
-        $radio_programs = $this->radio_program->getAllRadioPrograms();
+        $radio_station_id = $request->input('radio_station');
+        $radio_programs = $this->radio_program->getAllRadioPrograms($radio_station_id);
         if ($radio_programs) {
             return response()->json([
                 'radio_programs' => $radio_programs

--- a/app/Http/Controllers/RadioProgramController.php
+++ b/app/Http/Controllers/RadioProgramController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Services\Radio\RadioProgramService;
 use App\Http\Requests\RadioProgramRequest;
+use Illuminate\Http\Request;
 
 class RadioProgramController extends Controller
 {
@@ -15,6 +16,25 @@ class RadioProgramController extends Controller
     public function __construct(RadioProgramService $radio_program)
     {
         $this->radio_program = $radio_program;
+    }
+
+    /**
+     * ラジオ番組一覧取得
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function index()
+    {
+        $radio_programs = $this->radio_program->getAllRadioPrograms();
+        if ($radio_programs) {
+            return response()->json([
+                'radio_programs' => $radio_programs
+            ], 200, [], JSON_UNESCAPED_UNICODE);
+        } else {
+            return response()->json([
+                'message' => 'ラジオ局一覧の取得に失敗しました。'
+            ], 500, [], JSON_UNESCAPED_UNICODE);
+        }
     }
 
     /**

--- a/app/Services/Radio/RadioProgramService.php
+++ b/app/Services/Radio/RadioProgramService.php
@@ -40,13 +40,14 @@ class RadioProgramService
     }
 
     /**
-     * ラジオ番組一覧取得
+     * ラジオ局に紐づいたラジオ番組一覧取得
      * 
+     * @param int $radio_station_id ラジオ局ID
      * @return object ラジオ番組一覧
      */
-    public function getAllRadioPrograms(): object
+    public function getAllRadioPrograms(int $radio_station_id): object
     {
-        $radio_programs = $this->radio_program->getAllRadioPrograms();
+        $radio_programs = $this->radio_program->getAllRadioPrograms($radio_station_id);
         return $radio_programs;
     }
 

--- a/app/Services/Radio/RadioProgramService.php
+++ b/app/Services/Radio/RadioProgramService.php
@@ -40,6 +40,17 @@ class RadioProgramService
     }
 
     /**
+     * ラジオ番組一覧取得
+     * 
+     * @return object ラジオ番組一覧
+     */
+    public function getAllRadioPrograms(): object
+    {
+        $radio_programs = $this->radio_program->getAllRadioPrograms();
+        return $radio_programs;
+    }
+
+    /**
      * ラジオ番組作成
      *
      * @param RadioProgramRequest $request ラジオ番組作成リクエストデータ

--- a/tests/Feature/RadioProgramTest.php
+++ b/tests/Feature/RadioProgramTest.php
@@ -107,10 +107,16 @@ class RadioProgramTest extends TestCase
         $this->postJson('api/radio_programs', ['radio_station_id' => $this->radio_station->id, 'name' => 'テスト番組1', 'email' => 'test1@example.com']);
         $this->postJson('api/radio_programs', ['radio_station_id' => $this->radio_station->id, 'name' => 'テスト番組2', 'email' => 'test2@example.com']);
 
-        $response = $this->getJson('api/radio_programs');
+        $response = $this->getJson('api/radio_programs?radio_station=' . $this->radio_station->id);
 
         $response->assertStatus(200)
             ->assertJsonFragment(['name' => 'テスト番組1', 'email' => 'test1@example.com'])
             ->assertJsonFragment(['name' => 'テスト番組2', 'email' => 'test2@example.com']);
+
+        $response = $this->getJson('api/radio_programs?radio_station=' . 100000);
+
+        $response->assertStatus(200)
+            ->assertJsonMissing(['name' => 'テスト番組1', 'email' => 'test1@example.com'])
+            ->assertJsonMissing(['name' => 'テスト番組2', 'email' => 'test2@example.com']);
     }
 }

--- a/tests/Feature/RadioProgramTest.php
+++ b/tests/Feature/RadioProgramTest.php
@@ -97,4 +97,20 @@ class RadioProgramTest extends TestCase
                 ]
             ]);
     }
+
+    /**
+     * @test
+     * App\Http\Controllers\RadioProgramController@index
+     */
+    public function ラジオ番組一覧を取得できる()
+    {
+        $this->postJson('api/radio_programs', ['radio_station_id' => $this->radio_station->id, 'name' => 'テスト番組1', 'email' => 'test1@example.com']);
+        $this->postJson('api/radio_programs', ['radio_station_id' => $this->radio_station->id, 'name' => 'テスト番組2', 'email' => 'test2@example.com']);
+
+        $response = $this->getJson('api/radio_programs');
+
+        $response->assertStatus(200)
+            ->assertJsonFragment(['name' => 'テスト番組1', 'email' => 'test1@example.com'])
+            ->assertJsonFragment(['name' => 'テスト番組2', 'email' => 'test2@example.com']);
+    }
 }


### PR DESCRIPTION
## チケットへのリンク
https://trello.com/c/dCrRksUt/101-%E3%80%90api%E3%80%91%E3%83%A9%E3%82%B8%E3%82%AA%E7%95%AA%E7%B5%84%E5%8F%96%E5%BE%97api%E5%AE%9F%E8%A3%85
## やったこと

- ラジオ番組一覧取得APIの実装

## やらないこと

## できるようになること

- ラジオ局に紐づいたラジオ番組の一覧を取得できる

## できなくなること

## 動作確認有無

- Postmanで動作確認済み

## 参考URL

## その他