### PR TITLE
ラジオ番組個別取得API実装

### DIFF
--- a/app/DataProviders/Repositories/RadioProgramRepository.php
+++ b/app/DataProviders/Repositories/RadioProgramRepository.php
@@ -51,6 +51,17 @@ class RadioProgramRepository
     }
 
     /**
+     * 個別のラジオ番組取得
+     * 
+     * @param int $radio_station_id ラジオ局ID
+     * @return RadioProgram ラジオ番組データ
+     */
+    public function getSingleRadioProgram(int $radio_station_id): RadioProgram
+    {
+        return $this->radio_program::find($radio_station_id);
+    }
+
+    /**
      * ラジオ番組作成
      *
      * @param RadioProgramRequest $request ラジオ番組作成リクエストデータ

--- a/app/Http/Controllers/RadioProgramController.php
+++ b/app/Http/Controllers/RadioProgramController.php
@@ -40,6 +40,20 @@ class RadioProgramController extends Controller
     }
 
     /**
+     * 個別のラジオ番組取得
+     * 
+     * @param int $radio_program_id ラジオ番組ID
+     * @return \Illuminate\Http\Response
+     */
+    public function show(int $radio_program_id)
+    {
+        $radio_program = $this->radio_program->getSingleRadioProgram($radio_program_id);
+        return response()->json([
+            'radio_program' => $radio_program
+        ], 200, [], JSON_UNESCAPED_UNICODE);
+    }
+
+    /**
      * ラジオ番組作成
      *
      * @param  RadioProgramRequest $request ラジオ番組作成リクエストデータ

--- a/app/Http/Controllers/RadioProgramController.php
+++ b/app/Http/Controllers/RadioProgramController.php
@@ -34,7 +34,7 @@ class RadioProgramController extends Controller
             ], 200, [], JSON_UNESCAPED_UNICODE);
         } else {
             return response()->json([
-                'message' => 'ラジオ局一覧の取得に失敗しました。'
+                'message' => 'ラジオ番組一覧の取得に失敗しました。'
             ], 500, [], JSON_UNESCAPED_UNICODE);
         }
     }
@@ -48,9 +48,15 @@ class RadioProgramController extends Controller
     public function show(int $radio_program_id)
     {
         $radio_program = $this->radio_program->getSingleRadioProgram($radio_program_id);
-        return response()->json([
-            'radio_program' => $radio_program
-        ], 200, [], JSON_UNESCAPED_UNICODE);
+        if ($radio_program) {
+            return response()->json([
+                'radio_program' => $radio_program
+            ], 200, [], JSON_UNESCAPED_UNICODE);
+        } else {
+            return response()->json([
+                'message' => 'ラジオ番組の取得に失敗しました。'
+            ], 500, [], JSON_UNESCAPED_UNICODE);
+        }
     }
 
     /**

--- a/app/Services/Radio/RadioProgramService.php
+++ b/app/Services/Radio/RadioProgramService.php
@@ -52,6 +52,18 @@ class RadioProgramService
     }
 
     /**
+     * 個別のラジオ番組取得
+     *
+     * @param int $radio_station_id ラジオ局ID
+     * @return RadioProgram ラジオ番組データ
+     */
+    public function getSingleRadioProgram(int $radio_station_id): RadioProgram
+    {
+        $radio_program = $this->radio_program->getSingleRadioProgram($radio_station_id);
+        return $radio_program;
+    }
+
+    /**
      * ラジオ番組作成
      *
      * @param RadioProgramRequest $request ラジオ番組作成リクエストデータ

--- a/tests/Feature/RadioProgramTest.php
+++ b/tests/Feature/RadioProgramTest.php
@@ -119,4 +119,24 @@ class RadioProgramTest extends TestCase
             ->assertJsonMissing(['name' => 'テスト番組1', 'email' => 'test1@example.com'])
             ->assertJsonMissing(['name' => 'テスト番組2', 'email' => 'test2@example.com']);
     }
+
+    /**
+     * @test
+     * App\Http\Controllers\RadioProgramController@show
+     */
+    public function 個別のラジオ番組を取得できる()
+    {
+        $this->postJson('api/radio_programs', ['radio_station_id' => $this->radio_station->id, 'name' => 'テスト番組1', 'email' => 'test1@example.com']);
+        $radio_program = RadioProgram::first();
+
+        $response = $this->getJson('api/radio_programs/' . $radio_program->id);
+
+        $response->assertStatus(200)
+            ->assertJson([
+                'radio_program' => [
+                    'name' => 'テスト番組1',
+                    'email' => 'test1@example.com'
+                ]
+            ]);
+    }
 }


### PR DESCRIPTION
## チケットへのリンク
https://trello.com/c/QSd7OZfZ/287-%E3%80%90api%E3%80%91%E3%83%A9%E3%82%B8%E3%82%AA%E7%95%AA%E7%B5%84%E5%80%8B%E5%88%A5%E5%8F%96%E5%BE%97api%E5%AE%9F%E8%A3%85
## やったこと

- ラジオ番組個別取得APIの実装

## やらないこと

## できるようになること

- ラジオ番組IDから個別のラジオ番組を取得できる

## できなくなること

## 動作確認有無

- Postmanにて動作確認済み

## 参考URL

## その他