### PR TITLE
投稿テンプレート一覧取得API実装

### DIFF
--- a/app/DataProviders/Repositories/MessageTemplateRepository.php
+++ b/app/DataProviders/Repositories/MessageTemplateRepository.php
@@ -40,6 +40,17 @@ class MessageTemplateRepository
     }
 
     /**
+     * リスナーに紐づいた投稿テンプレート一覧の取得
+     * 
+     * @param int $listener_id リスナーID
+     * @return object 投稿テンプレート一覧
+     */
+    public function getAllMessageTemplates(int $listener_id): object
+    {
+        return $this->message_template::where('listener_id', $listener_id)->get();
+    }
+
+    /**
      * 投稿テンプレート作成
      *
      * @param MessageTemplateRequest $request 投稿テンプレート作成リクエストデータ

--- a/app/Http/Controllers/MessageTemplateController.php
+++ b/app/Http/Controllers/MessageTemplateController.php
@@ -18,6 +18,26 @@ class MessageTemplateController extends Controller
         $this->message_template = $message_template;
     }
 
+
+    /**
+     * リスナーに紐づいた投稿テンプレート一覧の取得
+     *
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function index()
+    {
+        try {
+            $message_templates = $this->message_template->getAllMessageTemplates(auth()->user()->id);
+            return response()->json([
+                'message_templates' => $message_templates
+            ], 200, [], JSON_UNESCAPED_UNICODE);
+        } catch (\Throwable $th) {
+            return response()->json([
+                'message' => '投稿テンプレート一覧の取得に失敗しました。'
+            ], 500, [], JSON_UNESCAPED_UNICODE);
+        }
+    }
+
     /**
      * 投稿テンプレート作成
      *

--- a/app/Services/Listener/MessageTemplateService.php
+++ b/app/Services/Listener/MessageTemplateService.php
@@ -40,6 +40,18 @@ class MessageTemplateService
     }
 
     /**
+     * リスナーに紐づいた投稿テンプレート一覧の取得
+     * 
+     * @param int $listener_id リスナーID
+     * @return object 投稿テンプレート一覧
+     */
+    public function getAllMessageTemplates(int $listener_id): object
+    {
+        $message_templates = $this->message_template->getAllMessageTemplates($listener_id);
+        return $message_templates;
+    }
+
+    /**
      * 投稿テンプレート作成
      * 
      * @param MessageTemplateRequest $request 投稿テンプレート登録用のリクエストデータ

--- a/tests/Feature/MessageTemplateTest.php
+++ b/tests/Feature/MessageTemplateTest.php
@@ -94,4 +94,22 @@ class MessageTemplateTest extends TestCase
 
         $this->assertEquals(0, MessageTemplate::count());
     }
+
+    /**
+     * @test
+     * App\Http\Controllers\MessageTemplateController@index
+     */
+    public function 投稿テンプレート一覧を取得できる()
+    {
+        $this->postJson('api/message_templates', ['name' => 'テストテンプレート1', 'content' => 'hello', 'listener_id' => $this->listener->id]);
+        $this->postJson('api/message_templates', ['name' => 'テストテンプレート2', 'content' => 'こんにちは', 'listener_id' => $this->listener->id]);
+
+        $response = $this->getJson('api/message_templates');
+
+        $response->assertStatus(200)
+            ->assertJsonFragment(['name' => 'テストテンプレート1'])
+            ->assertJsonFragment(['name' => 'テストテンプレート2'])
+            ->assertJsonFragment(['content' => 'hello'])
+            ->assertJsonFragment(['content' => 'こんにちは']);
+    }
 }


### PR DESCRIPTION
## チケットへのリンク
https://trello.com/c/oddrIaWc/113-%E3%80%90api%E3%80%91%E3%83%86%E3%83%B3%E3%83%97%E3%83%AC%E4%B8%80%E8%A6%A7%E5%8F%96%E5%BE%97api%E5%AE%9F%E8%A3%85-1pt
## やったこと

- 投稿テンプレート一覧取得APIの実装

## やらないこと

## できるようになること

- 投稿テンプレート一覧の取得ができる

## できなくなること

## 動作確認有無

- ログイン機能を作成次第Postmanで挙動確認

## 参考URL

## その他