### PR TITLE
投稿テンプレート個別取得APIの実装

### DIFF
--- a/app/DataProviders/Repositories/MessageTemplateRepository.php
+++ b/app/DataProviders/Repositories/MessageTemplateRepository.php
@@ -53,6 +53,7 @@ class MessageTemplateRepository
     /**
      * リスナーに紐づいた投稿テンプレート個別の取得
      * 
+     * @param int $listener_id リスナーID
      * @param int $message_template_id 投稿テンプレートID
      * @return MessageTemplate 投稿テンプレートデータ
      */

--- a/app/DataProviders/Repositories/MessageTemplateRepository.php
+++ b/app/DataProviders/Repositories/MessageTemplateRepository.php
@@ -51,6 +51,19 @@ class MessageTemplateRepository
     }
 
     /**
+     * リスナーに紐づいた投稿テンプレート個別の取得
+     * 
+     * @param int $message_template_id 投稿テンプレートID
+     * @return MessageTemplate 投稿テンプレートデータ
+     */
+    public function getSingleMessageTemplate(int $listener_id, int $message_template_id): MessageTemplate
+    {
+        return $this->radio_program::where('id', $message_template_id)
+            ->where('listener_id', $listener_id)
+            ->first();
+    }
+
+    /**
      * 投稿テンプレート作成
      *
      * @param MessageTemplateRequest $request 投稿テンプレート作成リクエストデータ

--- a/app/DataProviders/Repositories/MessageTemplateRepository.php
+++ b/app/DataProviders/Repositories/MessageTemplateRepository.php
@@ -58,7 +58,7 @@ class MessageTemplateRepository
      */
     public function getSingleMessageTemplate(int $listener_id, int $message_template_id): MessageTemplate
     {
-        return $this->radio_program::where('id', $message_template_id)
+        return $this->message_template::where('id', $message_template_id)
             ->where('listener_id', $listener_id)
             ->first();
     }

--- a/app/Http/Controllers/MessageTemplateController.php
+++ b/app/Http/Controllers/MessageTemplateController.php
@@ -18,7 +18,6 @@ class MessageTemplateController extends Controller
         $this->message_template = $message_template;
     }
 
-
     /**
      * リスナーに紐づいた投稿テンプレート一覧の取得
      *
@@ -34,6 +33,27 @@ class MessageTemplateController extends Controller
         } catch (\Throwable $th) {
             return response()->json([
                 'message' => '投稿テンプレート一覧の取得に失敗しました。'
+            ], 500, [], JSON_UNESCAPED_UNICODE);
+        }
+    }
+
+
+    /**
+     * リスナーに紐づいた投稿テンプレート個別の取得
+     * 
+     * @param int $message_template_id 投稿テンプレートID
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function show(int $message_template_id)
+    {
+        try {
+            $message_template = $this->message_template->getSingleMessageTemplate(auth()->user()->id, $message_template_id);
+            return response()->json([
+                'message_template' => $message_template
+            ], 200, [], JSON_UNESCAPED_UNICODE);
+        } catch (\Throwable $th) {
+            return response()->json([
+                'message' => '投稿テンプレート個別の取得に失敗しました。'
             ], 500, [], JSON_UNESCAPED_UNICODE);
         }
     }

--- a/app/Http/Controllers/MessageTemplateController.php
+++ b/app/Http/Controllers/MessageTemplateController.php
@@ -37,7 +37,6 @@ class MessageTemplateController extends Controller
         }
     }
 
-
     /**
      * リスナーに紐づいた投稿テンプレート個別の取得
      * 

--- a/app/Services/Listener/MessageTemplateService.php
+++ b/app/Services/Listener/MessageTemplateService.php
@@ -54,6 +54,7 @@ class MessageTemplateService
     /**
      * リスナーに紐づいた投稿テンプレート個別の取得
      *
+     * @param int $listener_id リスナーID
      * @param int $message_template_id 投稿テンプレートID
      * @return MessageTemplate 投稿テンプレートデータ
      */

--- a/app/Services/Listener/MessageTemplateService.php
+++ b/app/Services/Listener/MessageTemplateService.php
@@ -52,6 +52,18 @@ class MessageTemplateService
     }
 
     /**
+     * リスナーに紐づいた投稿テンプレート個別の取得
+     *
+     * @param int $message_template_id 投稿テンプレートID
+     * @return MessageTemplate 投稿テンプレートデータ
+     */
+    public function getSingleMessageTemplate(int $listener_id, int $message_template_id): MessageTemplate
+    {
+        $message_template = $this->message_template->getSingleMessageTemplate($listener_id, $message_template_id);
+        return $message_template;
+    }
+
+    /**
      * 投稿テンプレート作成
      * 
      * @param MessageTemplateRequest $request 投稿テンプレート登録用のリクエストデータ

--- a/tests/Feature/MessageTemplateTest.php
+++ b/tests/Feature/MessageTemplateTest.php
@@ -112,4 +112,25 @@ class MessageTemplateTest extends TestCase
             ->assertJsonFragment(['content' => 'hello'])
             ->assertJsonFragment(['content' => 'こんにちは']);
     }
+
+    /**
+     * @test
+     * App\Http\Controllers\MessageTemplateController@show
+     */
+    public function 個別の投稿テンプレートを取得できる()
+    {
+        $this->postJson('api/message_templates', ['name' => 'テストテンプレート1', 'content' => 'hello', 'listener_id' => $this->listener->id]);
+        $message_template = MessageTemplate::first();
+
+        $response = $this->getJson('api/message_templates/' . $message_template->id);
+
+        $response->assertStatus(200)
+            ->assertJson([
+                'message_template' => [
+                    'name' => 'テストテンプレート1',
+                    'content' => 'hello',
+                    'listener_id' => $this->listener->id
+                ]
+            ]);
+    }
 }


### PR DESCRIPTION
## チケットへのリンク
https://trello.com/c/Lz69WMVx/114-%E3%80%90api%E3%80%91%E3%83%86%E3%83%B3%E3%83%97%E3%83%AC%E5%80%8B%E5%88%A5%E5%8F%96%E5%BE%97api%E5%AE%9F%E8%A3%85-1pt
## やったこと

-  投稿テンプレート個別取得APIの実装

## やらないこと

## できるようになること

- 個別の投稿テンプレートを取得できるようになる

## できなくなること

## 動作確認有無

- ログイン機能実装後Postmanにて動作確認

## 参考URL

## その他