### PR TITLE
Feature/create message template edit api

### DIFF
--- a/app/DataProviders/Repositories/MessageTemplateRepository.php
+++ b/app/DataProviders/Repositories/MessageTemplateRepository.php
@@ -74,4 +74,22 @@ class MessageTemplateRepository
     {
         return $this->message_template::create($request->all());
     }
+
+    /**
+     * 投稿テンプレート更新
+     *
+     * @param MessageTemplateRequest $request 投稿テンプレート更新リクエストデータ
+     * @param int $listener_id リスナーID
+     * @param int $message_template_id 投稿テンプレートID
+     * @return bool 更新できたかどうか
+     */
+    public function updateMessageTemplate(MessageTemplateRequest $request, int $listener_id, int $message_template_id): bool
+    {
+        $message_template = $this->message_template::where('id', $message_template_id)
+            ->where('listener_id', $listener_id)
+            ->first();;
+        $message_template->name = $request->name;
+        $message_template->content = $request->content;
+        return $message_template->save();
+    }
 }

--- a/app/Http/Controllers/MessageTemplateController.php
+++ b/app/Http/Controllers/MessageTemplateController.php
@@ -77,4 +77,25 @@ class MessageTemplateController extends Controller
             ], 409, [], JSON_UNESCAPED_UNICODE);
         }
     }
+
+    /**
+     * 投稿テンプレート更新
+     *
+     * @param MessageTemplateRequest $request 投稿テンプレート更新リクエストデータ
+     * @param int $message_template_id 投稿テンプレートID
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function update(MessageTemplateRequest $request, int $message_template_id)
+    {
+        try {
+            $this->message_template->updateMessageTemplate($request, auth()->user()->id, $message_template_id);
+            return response()->json([
+                'message' => '投稿テンプレートが更新されました。'
+            ], 201, [], JSON_UNESCAPED_UNICODE);
+        } catch (\Throwable $th) {
+            return response()->json([
+                'message' => '投稿テンプレートの更新に失敗しました。'
+            ], 409, [], JSON_UNESCAPED_UNICODE);
+        }
+    }
 }

--- a/app/Services/Listener/MessageTemplateService.php
+++ b/app/Services/Listener/MessageTemplateService.php
@@ -75,4 +75,18 @@ class MessageTemplateService
         $message_template = $this->message_template->storeMessageTemplate($request);
         return $message_template;
     }
+
+    /**
+     * 投稿テンプレート更新
+     *
+     * @param MessageTemplateRequest $request 投稿テンプレート更新リクエストデータ
+     * @param int $listener_id リスナーID
+     * @param int $message_template_id 投稿テンプレートID
+     * @return bool 更新できたかどうか
+     */
+    public function updateMessageTemplate(MessageTemplateRequest $request, int $listener_id, int $message_template_id): bool
+    {
+        $message_template = $this->message_template->updateMessageTemplate($request, $listener_id, $message_template_id);
+        return $message_template;
+    }
 }

--- a/tests/Feature/MessageTemplateTest.php
+++ b/tests/Feature/MessageTemplateTest.php
@@ -133,4 +133,93 @@ class MessageTemplateTest extends TestCase
                 ]
             ]);
     }
+
+    /**
+     * @test
+     * App\Http\Controllers\MessageTemplateController@update
+     */
+    public function 投稿テンプレートを更新できる()
+    {
+        $this->postJson('api/message_templates', ['name' => 'テストテンプレート1', 'content' => 'hello', 'listener_id' => $this->listener->id]);
+        $message_template = MessageTemplate::first();
+
+        $response = $this->putJson('api/message_templates/' . $message_template->id, ['listener_id' => $this->listener->id, 'name' => 'テストテンプレート更新', 'content' => 'hello update']);
+        $response->assertStatus(201)
+            ->assertJson([
+                'message' => '投稿テンプレートが更新されました。'
+            ]);
+
+        $message_template = MessageTemplate::first();
+        $this->assertEquals('テストテンプレート更新', $message_template->name);
+        $this->assertEquals('hello update', $message_template->content);
+    }
+
+    /**
+     * @test
+     * App\Http\Controllers\MessageTemplateController@update
+     */
+    public function 投稿テンプレート更新に失敗する（名前関連）()
+    {
+        $this->postJson('api/message_templates', ['name' => 'テストテンプレート1', 'content' => 'hello', 'listener_id' => $this->listener->id]);
+        $message_template = MessageTemplate::first();
+
+        $response1 = $this->putJson('api/message_templates/' . $message_template->id, ['listener_id' => $this->listener->id, 'name' => '', 'content' => 'hello update']);
+        $response1->assertStatus(400)
+            ->assertJson([
+                'errors' => [
+                    'name' => [
+                        'テンプレート名を入力してください。'
+                    ]
+                ]
+            ]);
+
+        $response2 = $this->putJson('api/message_templates/' . $message_template->id, ['listener_id' => $this->listener->id, 'name' => str_repeat('あ', 151), 'content' => 'hello update']);
+        $response2->assertStatus(400)
+            ->assertJson([
+                'errors' => [
+                    'name' => [
+                        'テンプレート名は150文字以下で入力してください。'
+                    ]
+                ]
+            ]);
+
+        $message_template = MessageTemplate::first();
+        $this->assertEquals('テストテンプレート1', $message_template->name);
+        $this->assertEquals('hello', $message_template->content);
+    }
+
+    /**
+     * @test
+     * App\Http\Controllers\MessageTemplateController@update
+     */
+    public function 投稿テンプレート更新に失敗する（コンテンツ関連）()
+    {
+        $this->postJson('api/message_templates', ['name' => 'テストテンプレート1', 'content' => 'hello', 'listener_id' => $this->listener->id]);
+        $message_template = MessageTemplate::first();
+
+        $response1 = $this->putJson('api/message_templates/' . $message_template->id, ['listener_id' => $this->listener->id, 'name' => 'テストテンプレート1', 'content' => '']);
+        $response1->assertStatus(400)
+            ->assertJson([
+                'errors' => [
+                    'content' => [
+                        'テンプレート本文を入力してください。'
+                    ]
+                ]
+            ]);
+
+        $response2 = $this->putJson('api/message_templates/' . $message_template->id, ['listener_id' => $this->listener->id, 'name' => 'テストテンプレート1', 'content' => str_repeat('あ', 1001)]);
+        $response2->assertStatus(400)
+            ->assertJson([
+                'errors' => [
+                    'content' => [
+                        'テンプレート本文は1000文字以下で入力してください。'
+                    ]
+                ]
+            ]);
+
+
+        $message_template = MessageTemplate::first();
+        $this->assertEquals('テストテンプレート1', $message_template->name);
+        $this->assertEquals('hello', $message_template->content);
+    }
 }


### PR DESCRIPTION
## チケットへのリンク
https://trello.com/c/K9dnnKtQ/115-%E3%80%90api%E3%80%91%E3%83%86%E3%83%B3%E3%83%97%E3%83%AC%E6%9B%B4%E6%96%B0api%E5%AE%9F%E8%A3%85-1pt
## やったこと

- 投稿テンプレート更新APIの実装

## やらないこと

## できるようになること

- 投稿テンプレートを更新できるようになる

## できなくなること

## 動作確認有無

-  ログイン機能実装後Postmanにて動作確認

## 参考URL

## その他