### PR TITLE
投稿テンプレート削除APIの実装

### DIFF
--- a/app/DataProviders/Repositories/MessageTemplateRepository.php
+++ b/app/DataProviders/Repositories/MessageTemplateRepository.php
@@ -98,9 +98,9 @@ class MessageTemplateRepository
      *
      * @param int $listener_id リスナーID
      * @param int $message_template_id 投稿テンプレートID
-     * @return int 削除した件数
+     * @return bool 削除できたかどうか
      */
-    public function deleteMessageTemplate(int $listener_id, int $message_template_id): int
+    public function deleteMessageTemplate(int $listener_id, int $message_template_id): bool
     {
         $message_template = $this->message_template::where('id', $message_template_id)
             ->where('listener_id', $listener_id)

--- a/app/DataProviders/Repositories/MessageTemplateRepository.php
+++ b/app/DataProviders/Repositories/MessageTemplateRepository.php
@@ -100,7 +100,7 @@ class MessageTemplateRepository
      * @param int $message_template_id 投稿テンプレートID
      * @return int 削除した件数
      */
-    public function deleteProgramCorner(int $listener_id, int $message_template_id): int
+    public function deleteMessageTemplate(int $listener_id, int $message_template_id): int
     {
         $message_template = $this->message_template::where('id', $message_template_id)
             ->where('listener_id', $listener_id)

--- a/app/DataProviders/Repositories/MessageTemplateRepository.php
+++ b/app/DataProviders/Repositories/MessageTemplateRepository.php
@@ -87,9 +87,24 @@ class MessageTemplateRepository
     {
         $message_template = $this->message_template::where('id', $message_template_id)
             ->where('listener_id', $listener_id)
-            ->first();;
+            ->first();
         $message_template->name = $request->name;
         $message_template->content = $request->content;
         return $message_template->save();
+    }
+
+    /**
+     * 投稿テンプレート削除
+     *
+     * @param int $listener_id リスナーID
+     * @param int $message_template_id 投稿テンプレートID
+     * @return int 削除した件数
+     */
+    public function deleteProgramCorner(int $listener_id, int $message_template_id): int
+    {
+        $message_template = $this->message_template::where('id', $message_template_id)
+            ->where('listener_id', $listener_id)
+            ->first();
+        return $message_template->delete();
     }
 }

--- a/app/Http/Controllers/MessageTemplateController.php
+++ b/app/Http/Controllers/MessageTemplateController.php
@@ -107,13 +107,12 @@ class MessageTemplateController extends Controller
      */
     public function destroy(int $message_template_id)
     {
-        $message_templates_destroy_count = $this->message_template->deleteMessageTemplate(auth()->user()->id, $message_template_id);
-        // TODO: 分岐の条件検討する
-        if ($message_templates_destroy_count == 1) {
+        try {
+            $this->message_template->deleteMessageTemplate(auth()->user()->id, $message_template_id);
             return response()->json([
                 'message' => '投稿テンプレートが削除されました。'
             ], 200, [], JSON_UNESCAPED_UNICODE);
-        } else {
+        } catch (\Throwable $th) {
             return response()->json([
                 'message' => '投稿テンプレートの削除に失敗しました。'
             ], 500, [], JSON_UNESCAPED_UNICODE);

--- a/app/Http/Controllers/MessageTemplateController.php
+++ b/app/Http/Controllers/MessageTemplateController.php
@@ -98,4 +98,25 @@ class MessageTemplateController extends Controller
             ], 409, [], JSON_UNESCAPED_UNICODE);
         }
     }
+
+    /**
+     * 投稿テンプレート削除（1つのみ）
+     *
+     * @param int $message_template_id 投稿テンプレートID
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function destroy(int $message_template_id)
+    {
+        $message_templates_destroy_count = $this->message_template->deleteMessageTemplate(auth()->user()->id, $message_template_id);
+        // TODO: 分岐の条件検討する
+        if ($message_templates_destroy_count == 1) {
+            return response()->json([
+                'message' => '投稿テンプレートが削除されました。'
+            ], 200, [], JSON_UNESCAPED_UNICODE);
+        } else {
+            return response()->json([
+                'message' => '投稿テンプレートの削除に失敗しました。'
+            ], 500, [], JSON_UNESCAPED_UNICODE);
+        }
+    }
 }

--- a/app/Services/Listener/MessageTemplateService.php
+++ b/app/Services/Listener/MessageTemplateService.php
@@ -95,9 +95,9 @@ class MessageTemplateService
      *
      * @param int $listener_id リスナーID
      * @param int $message_template_id  投稿テンプレートID
-     * @return int 削除した件数
+     * @return bool 削除できたかどうか
      */
-    public function deleteMessageTemplate(int $listener_id, int $message_template_id): int
+    public function deleteMessageTemplate(int $listener_id, int $message_template_id): bool
     {
         $message_templates_destroy_count = $this->message_template->deleteMessageTemplate($listener_id, $message_template_id);
         return $message_templates_destroy_count;

--- a/app/Services/Listener/MessageTemplateService.php
+++ b/app/Services/Listener/MessageTemplateService.php
@@ -89,4 +89,17 @@ class MessageTemplateService
         $message_template = $this->message_template->updateMessageTemplate($request, $listener_id, $message_template_id);
         return $message_template;
     }
+
+    /**
+     * 投稿テンプレート削除
+     *
+     * @param int $listener_id リスナーID
+     * @param int $message_template_id  投稿テンプレートID
+     * @return int 削除した件数
+     */
+    public function deleteMessageTemplate(int $listener_id, int $message_template_id): int
+    {
+        $message_templates_destroy_count = $this->message_template->deleteMessageTemplate($listener_id, $message_template_id);
+        return $message_templates_destroy_count;
+    }
 }

--- a/app/Services/Listener/MessageTemplateService.php
+++ b/app/Services/Listener/MessageTemplateService.php
@@ -99,7 +99,7 @@ class MessageTemplateService
      */
     public function deleteMessageTemplate(int $listener_id, int $message_template_id): bool
     {
-        $message_templates_destroy_count = $this->message_template->deleteMessageTemplate($listener_id, $message_template_id);
-        return $message_templates_destroy_count;
+        $is_deleted = $this->message_template->deleteMessageTemplate($listener_id, $message_template_id);
+        return $is_deleted;
     }
 }

--- a/tests/Feature/MessageTemplateTest.php
+++ b/tests/Feature/MessageTemplateTest.php
@@ -222,4 +222,23 @@ class MessageTemplateTest extends TestCase
         $this->assertEquals('テストテンプレート1', $message_template->name);
         $this->assertEquals('hello', $message_template->content);
     }
+
+    /**
+     * @test
+     * App\Http\Controllers\MessageTemplateController@destory
+     */
+    public function 投稿テンプレートを削除できる()
+    {
+        $this->postJson('api/message_templates', ['name' => 'テストテンプレート1', 'content' => 'hello', 'listener_id' => $this->listener->id]);
+        $message_template = MessageTemplate::first();
+
+        $response = $this->deleteJson('api/message_templates/' . $message_template->id);
+
+        $response->assertStatus(200)
+            ->assertJson([
+                'message' => '投稿テンプレートが削除されました。'
+            ]);
+
+        $this->assertEquals(0, MessageTemplate::count());
+    }
 }


### PR DESCRIPTION
## チケットへのリンク
https://trello.com/c/KNrh5Wpn/116-%E3%80%90api%E3%80%91%E3%83%86%E3%83%B3%E3%83%97%E3%83%AC%E5%89%8A%E9%99%A4api%E5%AE%9F%E8%A3%85-1pt
## やったこと

- 投稿テンプレート削除APIの実装

## やらないこと

## できるようになること

- 投稿テンプレートを削除できる

## できなくなること

## 動作確認有無

- ログイン機能実装後Postmanで動作確認

## 参考URL

## その他