### PR TITLE
マイ番組一覧取得APIの実装

### DIFF
--- a/app/DataProviders/Repositories/ListenerMyProgramRepository.php
+++ b/app/DataProviders/Repositories/ListenerMyProgramRepository.php
@@ -40,6 +40,17 @@ class ListenerMyProgramRepository
     }
 
     /**
+     * リスナーに紐づいたマイ番組一覧の取得
+     * 
+     * @param int $listener_id リスナーID
+     * @return object マイ番組一覧
+     */
+    public function getAllListenerMyPrograms(int $listener_id): object
+    {
+        return $this->listener_my_program::where('listener_id', $listener_id)->get();
+    }
+
+    /**
      * マイ番組作成
      *
      * @param ListenerMyProgramRequest $request マイ番組作成リクエストデータ

--- a/app/Http/Controllers/ListenerMyProgramController.php
+++ b/app/Http/Controllers/ListenerMyProgramController.php
@@ -18,6 +18,25 @@ class ListenerMyProgramController extends Controller
     }
 
     /**
+     * リスナーに紐づいたマイ番組一覧の取得
+     *
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function index()
+    {
+        try {
+            $listener_my_programs = $this->listener_my_program->getAllListenerMyPrograms(auth()->user()->id);
+            return response()->json([
+                'listener_my_programs' => $listener_my_programs
+            ], 200, [], JSON_UNESCAPED_UNICODE);
+        } catch (\Throwable $th) {
+            return response()->json([
+                'message' => 'マイ番組一覧の取得に失敗しました。'
+            ], 500, [], JSON_UNESCAPED_UNICODE);
+        }
+    }
+
+    /**
      * マイ番組作成
      *
      * @param ListenerMyProgramRequest $request マイ番組作成リクエストデータ

--- a/app/Services/Listener/ListenerMyProgramService.php
+++ b/app/Services/Listener/ListenerMyProgramService.php
@@ -40,6 +40,18 @@ class ListenerMyProgramService
     }
 
     /**
+     * リスナーに紐づいたマイ番組一覧の取得
+     * 
+     * @param int $listener_id リスナーID
+     * @return object マイ番組一覧
+     */
+    public function getAllListenerMyPrograms(int $listener_id): object
+    {
+        $listener_my_programs = $this->listener_my_program->getAllListenerMyPrograms($listener_id);
+        return $listener_my_programs;
+    }
+
+    /**
      * マイ番組作成
      * 
      * @param int $listener_id リスナーID

--- a/tests/Feature/ListenerMyProgramTest.php
+++ b/tests/Feature/ListenerMyProgramTest.php
@@ -87,4 +87,23 @@ class ListenerMyProgramTest extends TestCase
 
         $this->assertEquals(1, ListenerMyProgram::count());
     }
+
+    /**
+     * @test
+     * App\Http\Controllers\ListenerMyProgramController@index
+     */
+    public function マイ番組一覧を取得できる()
+    {
+        $this->postJson('api/listener_my_programs', ['program_name' => 'テストマイ番組1', 'email' => 'test1@example.com']);
+        $this->postJson('api/listener_my_programs', ['program_name' => 'テストマイ番組2', 'email' => 'test2@example.com']);
+
+
+        $response = $this->getJson('api/listener_my_programs');
+
+        $response->assertStatus(200)
+            ->assertJsonFragment(['program_name' => 'テストマイ番組1'])
+            ->assertJsonFragment(['program_name' => 'テストマイ番組2'])
+            ->assertJsonFragment(['email' => 'test1@example.com'])
+            ->assertJsonFragment(['email' => 'test2@example.com']);
+    }
 }


### PR DESCRIPTION
## チケットへのリンク
https://trello.com/c/WFHdNwCa/118-%E3%80%90api%E3%80%91%E3%83%9E%E3%82%A4%E7%95%AA%E7%B5%84%E4%B8%80%E8%A6%A7%E5%8F%96%E5%BE%97api%E5%AE%9F%E8%A3%85-1pt
## やったこと

- マイ番組一覧取得APIの実装

## やらないこと

## できるようになること

-  マイ番組の一覧を取得できる

## できなくなること

## 動作確認有無

-  ログイン機能実装後Postmanで動作確認

## 参考URL

## その他