### PR TITLE
マイ番組個別取得API実装

### DIFF
--- a/app/DataProviders/Repositories/ListenerMyProgramRepository.php
+++ b/app/DataProviders/Repositories/ListenerMyProgramRepository.php
@@ -51,6 +51,20 @@ class ListenerMyProgramRepository
     }
 
     /**
+     * リスナーに紐づいたマイ番組個別の取得
+     * 
+     * @param int $listener_id リスナーID
+     * @param int $listener_my_program_id マイ番組ID
+     * @return ListenerMyProgram マイ番組データ
+     */
+    public function getSingleListenerMyProgram(int $listener_id, int $listener_my_program_id): ListenerMyProgram
+    {
+        return $this->listener_my_program::where('id', $listener_my_program_id)
+            ->where('listener_id', $listener_id)
+            ->first();
+    }
+
+    /**
      * マイ番組作成
      *
      * @param ListenerMyProgramRequest $request マイ番組作成リクエストデータ

--- a/app/Http/Controllers/ListenerMyProgramController.php
+++ b/app/Http/Controllers/ListenerMyProgramController.php
@@ -37,6 +37,26 @@ class ListenerMyProgramController extends Controller
     }
 
     /**
+     * リスナーに紐づいたマイ番組個別の取得
+     * 
+     * @param int $listener_my_program_id マイ番組ID
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function show(int $listener_my_program_id)
+    {
+        try {
+            $listener_my_program = $this->listener_my_program->getSingleListenerMyProgram(auth()->user()->id, $listener_my_program_id);
+            return response()->json([
+                'listener_my_program' => $listener_my_program
+            ], 200, [], JSON_UNESCAPED_UNICODE);
+        } catch (\Throwable $th) {
+            return response()->json([
+                'message' => 'マイ番組個別の取得に失敗しました。'
+            ], 500, [], JSON_UNESCAPED_UNICODE);
+        }
+    }
+
+    /**
      * マイ番組作成
      *
      * @param ListenerMyProgramRequest $request マイ番組作成リクエストデータ

--- a/app/Services/Listener/ListenerMyProgramService.php
+++ b/app/Services/Listener/ListenerMyProgramService.php
@@ -52,6 +52,19 @@ class ListenerMyProgramService
     }
 
     /**
+     * リスナーに紐づいたマイ番組個別の取得
+     *
+     * @param int $listener_id リスナーID
+     * @param int $listener_my_program_id マイ番組ID
+     * @return ListenerMyProgram マイ番組データ
+     */
+    public function getSingleListenerMyProgram(int $listener_id, int $listener_my_program_id): ListenerMyProgram
+    {
+        $listener_my_program = $this->listener_my_program->getSingleListenerMyProgram($listener_id, $listener_my_program_id);
+        return $listener_my_program;
+    }
+
+    /**
      * マイ番組作成
      * 
      * @param int $listener_id リスナーID

--- a/tests/Feature/ListenerMyProgramTest.php
+++ b/tests/Feature/ListenerMyProgramTest.php
@@ -106,4 +106,25 @@ class ListenerMyProgramTest extends TestCase
             ->assertJsonFragment(['email' => 'test1@example.com'])
             ->assertJsonFragment(['email' => 'test2@example.com']);
     }
+
+    /**
+     * @test
+     * App\Http\Controllers\ListenerMyProgramController@show
+     */
+    public function 個別の投稿テンプレートを取得できる()
+    {
+        $this->postJson('api/listener_my_programs', ['program_name' => 'テストマイ番組1', 'email' => 'test1@example.com']);
+        $listener_my_program = ListenerMyProgram::first();
+
+        $response = $this->getJson('api/listener_my_programs/' . $listener_my_program->id);
+
+        $response->assertStatus(200)
+            ->assertJson([
+                'listener_my_program' => [
+                    'program_name' => 'テストマイ番組1',
+                    'email' => 'test1@example.com',
+                    'listener_id' => $this->listener->id
+                ]
+            ]);
+    }
 }


### PR DESCRIPTION
## チケットへのリンク
https://trello.com/c/LghI71iZ/119-%E3%80%90api%E3%80%91%E3%83%9E%E3%82%A4%E7%95%AA%E7%B5%84%E5%80%8B%E5%88%A5%E5%8F%96%E5%BE%97api%E5%AE%9F%E8%A3%85-1pt
## やったこと

- マイ番組個別取得APIの実装

## やらないこと

## できるようになること

- 個別のマイ番組を取得できる

## できなくなること

## 動作確認有無

- ログイン機能実装後Postmanにて動作確認

## 参考URL

## その他