### PR TITLE
マイ番組更新APIの実装

### DIFF
--- a/app/DataProviders/Repositories/ListenerMyProgramRepository.php
+++ b/app/DataProviders/Repositories/ListenerMyProgramRepository.php
@@ -78,4 +78,22 @@ class ListenerMyProgramRepository
             'listener_id' => $listener_id
         ]);
     }
+
+    /**
+     * マイ番組更新
+     *
+     * @param ListenerMyProgramRequest $request マイ番組更新リクエストデータ
+     * @param int $listener_id リスナーID
+     * @param int $listener_my_program_id マイ番組ID
+     * @return bool 更新できたかどうか
+     */
+    public function updateListenerMyProgram(ListenerMyProgramRequest $request, int $listener_id, int $listener_my_program_id): bool
+    {
+        $listener_my_program = $this->listener_my_program::where('id', $listener_my_program_id)
+            ->where('listener_id', $listener_id)
+            ->first();
+        $listener_my_program->program_name = $request->program_name;
+        $listener_my_program->email = $request->email;
+        return $listener_my_program->save();
+    }
 }

--- a/app/Http/Controllers/ListenerMyProgramController.php
+++ b/app/Http/Controllers/ListenerMyProgramController.php
@@ -75,4 +75,25 @@ class ListenerMyProgramController extends Controller
             ], 409, [], JSON_UNESCAPED_UNICODE);
         }
     }
+
+    /**
+     * マイ番組更新
+     *
+     * @param ListenerMyProgramRequest $request マイ番組更新リクエストデータ
+     * @param int $listener_my_program_id マイ番組ID
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function update(ListenerMyProgramRequest $request, int $listener_my_program_id)
+    {
+        try {
+            $this->listener_my_program->updateListenerMyProgram($request, auth()->user()->id, $listener_my_program_id);
+            return response()->json([
+                'message' => 'マイ番組が更新されました。'
+            ], 201, [], JSON_UNESCAPED_UNICODE);
+        } catch (\Throwable $th) {
+            return response()->json([
+                'message' => 'マイ番組の更新に失敗しました。'
+            ], 409, [], JSON_UNESCAPED_UNICODE);
+        }
+    }
 }

--- a/app/Services/Listener/ListenerMyProgramService.php
+++ b/app/Services/Listener/ListenerMyProgramService.php
@@ -76,4 +76,18 @@ class ListenerMyProgramService
         $listener_my_program = $this->listener_my_program->storeListenerMyProgram($request, $listener_id);
         return $listener_my_program;
     }
+
+    /**
+     * マイ番組更新
+     *
+     * @param ListenerMyProgramRequest $request マイ番組更新リクエストデータ
+     * @param int $listener_id リスナーID
+     * @param int $listener_my_program_id マイ番組ID
+     * @return bool 更新できたかどうか
+     */
+    public function updateListenerMyProgram(ListenerMyProgramRequest $request, int $listener_id, int $listener_my_program_id): bool
+    {
+        $listener_my_program = $this->listener_my_program->updateListenerMyProgram($request, $listener_id, $listener_my_program_id);
+        return $listener_my_program;
+    }
 }

--- a/tests/Feature/ListenerMyProgramTest.php
+++ b/tests/Feature/ListenerMyProgramTest.php
@@ -127,4 +127,85 @@ class ListenerMyProgramTest extends TestCase
                 ]
             ]);
     }
+
+    /**
+     * @test
+     * App\Http\Controllers\ListenerMyProgramController@update
+     */
+    public function マイ番組を更新できる()
+    {
+        $this->postJson('api/listener_my_programs', ['program_name' => 'テストマイ番組1', 'email' => 'test1@example.com']);
+        $listener_my_program = ListenerMyProgram::first();
+
+        $response = $this->putJson('api/listener_my_programs/' . $listener_my_program->id, ['listener_id' => $this->listener->id, 'program_name' => 'テストマイ番組更新', 'email' => 'testupdate@example.com']);
+        $response->assertStatus(201)
+            ->assertJson([
+                'message' => 'マイ番組が更新されました。'
+            ]);
+
+        $listener_my_program = ListenerMyProgram::first();
+        $this->assertEquals('テストマイ番組更新', $listener_my_program->program_name);
+        $this->assertEquals('testupdate@example.com', $listener_my_program->email);
+    }
+
+    /**
+     * @test
+     * App\Http\Controllers\ListenerMyProgramController@update
+     */
+    public function マイ番組更新に失敗する（名前関連）()
+    {
+        $this->postJson('api/listener_my_programs', ['program_name' => 'テストマイ番組1', 'email' => 'test1@example.com']);
+        $listener_my_program = ListenerMyProgram::first();
+
+        $response1 = $this->putJson('api/listener_my_programs/' . $listener_my_program->id, ['listener_id' => $this->listener->id, 'program_name' => '', 'email' => 'testupdate@example.com']);
+        $response1->assertStatus(422)
+            ->assertJsonValidationErrors([
+                'program_name' => [
+                    '番組名を入力してください。'
+                ]
+            ]);
+
+        $response2 = $this->putJson('api/listener_my_programs/' . $listener_my_program->id, ['listener_id' => $this->listener->id, 'program_name' => str_repeat('あ', 151), 'email' => 'testupdate@example.com']);
+        $response2->assertStatus(422)
+            ->assertJsonValidationErrors([
+                'program_name' => [
+                    '番組名は150文字以下で入力してください。'
+                ]
+            ]);
+
+        $listener_my_program = ListenerMyProgram::first();
+        $this->assertEquals('テストマイ番組1', $listener_my_program->program_name);
+        $this->assertEquals('test1@example.com', $listener_my_program->email);
+    }
+
+    /**
+     * @test
+     * App\Http\Controllers\ListenerMyProgramController@update
+     */
+    public function マイ番組更新に失敗する（メールアドレス関連）()
+    {
+        $this->postJson('api/listener_my_programs', ['program_name' => 'テストマイ番組1', 'email' => 'test1@example.com']);
+        $this->postJson('api/listener_my_programs', ['program_name' => 'テストマイ番組1', 'email' => 'test2@example.com']);
+        $listener_my_program = ListenerMyProgram::first();
+
+        $response1 = $this->putJson('api/listener_my_programs/' . $listener_my_program->id, ['listener_id' => $this->listener->id, 'program_name' => 'テストマイ番組1', 'email' => '']);
+        $response1->assertStatus(422)
+            ->assertJsonValidationErrors([
+                'email' => [
+                    '番組メールアドレスを入力してください。'
+                ]
+            ]);
+
+        $response2 = $this->putJson('api/listener_my_programs/' . $listener_my_program->id, ['listener_id' => $this->listener->id, 'program_name' => 'テストマイ番組1', 'email' => 'test2@example.com']);
+        $response2->assertStatus(422)
+            ->assertJsonValidationErrors([
+                'email' => [
+                    '番組メールアドレスは既に保存されています。'
+                ]
+            ]);
+
+        $listener_my_program = ListenerMyProgram::first();
+        $this->assertEquals('テストマイ番組1', $listener_my_program->program_name);
+        $this->assertEquals('test1@example.com', $listener_my_program->email);
+    }
 }


### PR DESCRIPTION
## チケットへのリンク
https://trello.com/c/8grg9o0M/120-%E3%80%90api%E3%80%91%E3%83%9E%E3%82%A4%E7%95%AA%E7%B5%84%E6%9B%B4%E6%96%B0api%E5%AE%9F%E8%A3%85-1pt
## やったこと

- マイ番組更新APIの実装

## やらないこと

## できるようになること

- マイ番組を更新できる

## できなくなること

## 動作確認有無

- ログイン機能実装後Postmanにて動作確認

## 参考URL

## その他