### PR TITLE
マイ番組削除API実装

### DIFF
--- a/app/DataProviders/Repositories/ListenerMyProgramRepository.php
+++ b/app/DataProviders/Repositories/ListenerMyProgramRepository.php
@@ -96,4 +96,19 @@ class ListenerMyProgramRepository
         $listener_my_program->email = $request->email;
         return $listener_my_program->save();
     }
+
+    /**
+     * マイ番組削除
+     *
+     * @param int $listener_id リスナーID
+     * @param int $listener_my_program_id マイ番組ID
+     * @return bool 削除できたかどうか
+     */
+    public function deleteListenerMyProgram(int $listener_id, int $listener_my_program_id): bool
+    {
+        $listener_my_program = $this->listener_my_program::where('id', $listener_my_program_id)
+            ->where('listener_id', $listener_id)
+            ->first();
+        return $listener_my_program->delete();
+    }
 }

--- a/app/Http/Controllers/ListenerMyProgramController.php
+++ b/app/Http/Controllers/ListenerMyProgramController.php
@@ -96,4 +96,24 @@ class ListenerMyProgramController extends Controller
             ], 409, [], JSON_UNESCAPED_UNICODE);
         }
     }
+
+    /**
+     * マイ番組削除（1つのみ）
+     *
+     * @param int $listener_my_program_id マイ番組ID
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function destroy(int $listener_my_program_id)
+    {
+        try {
+            $this->listener_my_program->deleteListenerMyProgram(auth()->user()->id, $listener_my_program_id);
+            return response()->json([
+                'message' => 'マイ番組が削除されました。'
+            ], 200, [], JSON_UNESCAPED_UNICODE);
+        } catch (\Throwable $th) {
+            return response()->json([
+                'message' => 'マイ番組の削除に失敗しました。'
+            ], 500, [], JSON_UNESCAPED_UNICODE);
+        }
+    }
 }

--- a/app/Services/Listener/ListenerMyProgramService.php
+++ b/app/Services/Listener/ListenerMyProgramService.php
@@ -90,4 +90,17 @@ class ListenerMyProgramService
         $listener_my_program = $this->listener_my_program->updateListenerMyProgram($request, $listener_id, $listener_my_program_id);
         return $listener_my_program;
     }
+
+    /**
+     * マイ番組削除
+     *
+     * @param int $listener_id リスナーID
+     * @param int $listener_my_program_id  マイ番組ID
+     * @return bool 削除できたかどうか
+     */
+    public function deleteListenerMyProgram(int $listener_id, int $listener_my_program_id): bool
+    {
+        $is_deleted = $this->listener_my_program->deleteListenerMyProgram($listener_id, $listener_my_program_id);
+        return $is_deleted;
+    }
 }

--- a/tests/Feature/ListenerMyProgramTest.php
+++ b/tests/Feature/ListenerMyProgramTest.php
@@ -208,4 +208,23 @@ class ListenerMyProgramTest extends TestCase
         $this->assertEquals('テストマイ番組1', $listener_my_program->program_name);
         $this->assertEquals('test1@example.com', $listener_my_program->email);
     }
+
+    /**
+     * @test
+     * App\Http\Controllers\ListenerMyProgramController@destory
+     */
+    public function マイ番組を削除できる()
+    {
+        $this->postJson('api/listener_my_programs', ['program_name' => 'テストマイ番組1', 'email' => 'test1@example.com']);
+        $listener_my_program = ListenerMyProgram::first();
+
+        $response = $this->deleteJson('api/listener_my_programs/' . $listener_my_program->id);
+
+        $response->assertStatus(200)
+            ->assertJson([
+                'message' => 'マイ番組が削除されました。'
+            ]);
+
+        $this->assertEquals(0, ListenerMyProgram::count());
+    }
 }


### PR DESCRIPTION
## チケットへのリンク
https://trello.com/c/Ka9G3eel/121-%E3%80%90api%E3%80%91%E3%83%9E%E3%82%A4%E7%95%AA%E7%B5%84%E5%89%8A%E9%99%A4api%E5%AE%9F%E8%A3%85-1pt
## やったこと

- マイ番組削除APIの実装

## やらないこと

## できるようになること

- マイ番組を削除できる

## できなくなること

## 動作確認有無

- ログイン機能実装後Postmanで動作確認

## 参考URL

## その他