### PR TITLE
マイ番組コーナー取得APIの実装

### DIFF
--- a/app/DataProviders/Repositories/MyProgramCornerRepository.php
+++ b/app/DataProviders/Repositories/MyProgramCornerRepository.php
@@ -40,6 +40,17 @@ class MyProgramCornerRepository
     }
 
     /**
+     * マイ番組に紐づいたコーナー一覧取得
+     * 
+     * @param int $listener_my_program_id マイ番組ID
+     * @return object コーナー一覧
+     */
+    public function getAllMyProgramCorners(int $listener_my_program_id): object
+    {
+        return $this->my_program_corner::where('listener_my_program_id', $listener_my_program_id)->get();
+    }
+
+    /**
      * マイ番組作成
      *
      * @param MyProgramCornerRequest $request マイ番組作成リクエストデータ

--- a/app/Http/Controllers/MyProgramCornerController.php
+++ b/app/Http/Controllers/MyProgramCornerController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Services\Listener\MyProgramCornerService;
 use App\Http\Requests\MyProgramCornerRequest;
+use Illuminate\Http\Request;
 
 class MyProgramCornerController extends Controller
 {
@@ -16,6 +17,35 @@ class MyProgramCornerController extends Controller
     {
         $this->my_program_corner = $my_program_corner;
     }
+
+    /**
+     * マイ番組に紐づいたコーナーの取得
+     *
+     * @param Request $request マイ番組ID用のgetパラメーター
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function index(Request $request)
+    {
+        $listener_my_program_id = $request->input('listener_my_program');
+        $listener_id = $request->input('listener');
+        if ($listener_id !== auth()->user()->id) {
+            return response()->json([
+                'message' => 'ログインし直してください。'
+            ], 409, [], JSON_UNESCAPED_UNICODE);
+        }
+
+        try {
+            $my_program_corners = $this->my_program_corner->getAllMyProgramCorners($listener_my_program_id);
+            return response()->json([
+                'my_program_corners' => $my_program_corners
+            ], 200, [], JSON_UNESCAPED_UNICODE);
+        } catch (\Throwable $th) {
+            return response()->json([
+                'message' => 'マイ番組コーナー一覧の取得に失敗しました。'
+            ], 500, [], JSON_UNESCAPED_UNICODE);
+        }
+    }
+
     /**
      * マイ番組コーナー作成
      *

--- a/app/Http/Controllers/MyProgramCornerController.php
+++ b/app/Http/Controllers/MyProgramCornerController.php
@@ -27,7 +27,7 @@ class MyProgramCornerController extends Controller
     public function index(Request $request)
     {
         $listener_my_program_id = $request->input('listener_my_program');
-        $listener_id = $request->input('listener');
+        $listener_id = (int) $request->input('listener');
         if ($listener_id !== auth()->user()->id) {
             return response()->json([
                 'message' => 'ログインし直してください。'

--- a/app/Services/Listener/MyProgramCornerService.php
+++ b/app/Services/Listener/MyProgramCornerService.php
@@ -40,6 +40,18 @@ class MyProgramCornerService
     }
 
     /**
+     * マイ番組に紐づいたコーナー一覧取得
+     * 
+     * @param int $listener_my_program_id マイ番組ID
+     * @return object コーナー一覧
+     */
+    public function getAllMyProgramCorners(int $listener_my_program_id): object
+    {
+        $my_program_corners = $this->my_program_corner->getAllMyProgramCorners($listener_my_program_id);
+        return $my_program_corners;
+    }
+
+    /**
      * マイ番組コーナー作成
      * 
      * @param MyProgramCornerRequest $request マイ番組コーナー登録用のリクエストデータ

--- a/tests/Feature/MyProgramCornerTest.php
+++ b/tests/Feature/MyProgramCornerTest.php
@@ -80,4 +80,31 @@ class MyProgramCornerTest extends TestCase
 
         $this->assertEquals(0, MyProgramCorner::count());
     }
+
+    /**
+     * @test
+     * App\Http\Controllers\MyProgramCornerController@index
+     */
+    public function 番組コーナー一覧を取得できる()
+    {
+        $this->postJson('api/my_program_corners', ['listener_my_program_id' => $this->listener_my_program->id, 'name' => 'BBSリクエスト', 'listener_id' => $this->listener->id]);
+        $this->postJson('api/my_program_corners', ['listener_my_program_id' => $this->listener_my_program->id, 'name' => 'ザワニュー', 'listener_id' => $this->listener->id]);
+
+        $response = $this->getJson('api/my_program_corners?listener_my_program=' . $this->listener_my_program->id . '&listener=' . $this->listener->id);
+
+        $response->assertStatus(200)
+            ->assertJsonFragment(['name' => 'BBSリクエスト'])
+            ->assertJsonFragment(['name' => 'ザワニュー']);
+
+        $response = $this->getJson('api/my_program_corners?listener_my_program=' . 100000 . '&listener=' . $this->listener->id);
+        $response->assertStatus(200)
+            ->assertJsonMissing(['name' => 'BBSリクエスト'])
+            ->assertJsonMissing(['name' => 'ザワニュー']);
+
+        $response = $this->getJson('api/my_program_corners?listener_my_program=' . $this->listener_my_program->id . '&listener=111111');
+        $response->assertStatus(409)
+            ->assertJson([
+                'message' => 'ログインし直してください。'
+            ]);
+    }
 }


### PR DESCRIPTION
## チケットへのリンク
https://trello.com/c/0xx1G7Bj/302-%E3%80%90api%E3%80%91%E3%83%9E%E3%82%A4%E7%95%AA%E7%B5%84%E3%82%B3%E3%83%BC%E3%83%8A%E3%83%BC%E5%8F%96%E5%BE%97api%E5%AE%9F%E8%A3%85
## やったこと

- マイ番組コーナー取得APIの実装

## やらないこと

## できるようになること

- マイ番組コーナーを取得できるようになる

## できなくなること

## 動作確認有無

- ログイン機能実装後Postmanにて動作確認

## 参考URL

## その他