### PR TITLE
マイ番組コーナー更新APIの実装

### DIFF
--- a/app/DataProviders/Repositories/MyProgramCornerRepository.php
+++ b/app/DataProviders/Repositories/MyProgramCornerRepository.php
@@ -63,4 +63,18 @@ class MyProgramCornerRepository
             'listener_my_program_id' => $request->listener_my_program_id
         ]);
     }
+
+    /**
+     * マイ番組コーナー更新
+     *
+     * @param MyProgramCornerRequest $request マイ番組コーナー更新リクエストデータ
+     * @param int $my_program_corner_id マイ番組コーナーID
+     * @return bool 更新できたかどうか
+     */
+    public function updateMyProgramCorner(MyProgramCornerRequest $request, int $my_program_corner_id): bool
+    {
+        $my_program_corner = $this->my_program_corner::find($my_program_corner_id);
+        $my_program_corner->name = $request->name;
+        return $my_program_corner->save();
+    }
 }

--- a/app/Http/Controllers/MyProgramCornerController.php
+++ b/app/Http/Controllers/MyProgramCornerController.php
@@ -71,4 +71,31 @@ class MyProgramCornerController extends Controller
             ], 409, [], JSON_UNESCAPED_UNICODE);
         }
     }
+
+    /**
+     * マイ番組コーナ更新
+     *
+     * @param MyProgramCornerRequest $request マイ番組コーナー作成リクエストデータ
+     * @param int $my_program_corner_id マイ番組コーナーID
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function update(MyProgramCornerRequest $request, $my_program_corner_id)
+    {
+        if ($request->listener_id !== auth()->user()->id) {
+            return response()->json([
+                'message' => 'ログインし直してください。'
+            ], 409, [], JSON_UNESCAPED_UNICODE);
+        }
+
+        try {
+            $this->my_program_corner->updateMyProgramCorner($request, $my_program_corner_id);
+            return response()->json([
+                'message' => 'マイ番組コーナーが更新されました。'
+            ], 201, [], JSON_UNESCAPED_UNICODE);
+        } catch (\Throwable $th) {
+            return response()->json([
+                'message' => 'マイ番組コーナーの更新に失敗しました。'
+            ], 409, [], JSON_UNESCAPED_UNICODE);
+        }
+    }
 }

--- a/app/Services/Listener/MyProgramCornerService.php
+++ b/app/Services/Listener/MyProgramCornerService.php
@@ -62,4 +62,17 @@ class MyProgramCornerService
         $my_program_corner = $this->my_program_corner->storeMyProgramCorner($request);
         return $my_program_corner;
     }
+
+    /**
+     * マイ番組コーナー更新
+     *
+     * @param MyProgramCornerRequest $request マイ番組コーナー更新リクエストデータ
+     * @param int $my_program_corner_id マイ番組コーナーID
+     * @return bool 更新できたかどうか
+     */
+    public function updateMyProgramCorner(MyProgramCornerRequest $request, int $my_program_corner_id): bool
+    {
+        $my_program_corner = $this->my_program_corner->updateMyProgramCorner($request, $my_program_corner_id);
+        return $my_program_corner;
+    }
 }

--- a/tests/Feature/MyProgramCornerTest.php
+++ b/tests/Feature/MyProgramCornerTest.php
@@ -107,4 +107,71 @@ class MyProgramCornerTest extends TestCase
                 'message' => 'ログインし直してください。'
             ]);
     }
+
+    /**
+     * @test
+     * App\Http\Controllers\MyProgramCornerController@update
+     */
+    public function 番組コーナーを更新できる()
+    {
+        $this->postJson('api/my_program_corners', ['listener_my_program_id' => $this->listener_my_program->id, 'name' => 'BBSリクエスト', 'listener_id' => $this->listener->id]);
+        $my_program_corner = MyProgramCorner::first();
+
+        $response = $this->putJson('api/my_program_corners/' . $my_program_corner->id, ['listener_my_program_id' => $this->listener_my_program->id, 'name' => 'ザワニュー', 'listener_id' => $this->listener->id]);
+        $response->assertStatus(201)
+            ->assertJson([
+                'message' => 'マイ番組コーナーが更新されました。'
+            ]);
+
+        $my_program_corner = MyProgramCorner::first();
+        $this->assertEquals('ザワニュー', $my_program_corner->name);
+    }
+
+    /**
+     * @test
+     * App\Http\Controllers\MyProgramCornerController@update
+     */
+    public function 番組コーナー更新に失敗する（名前関連）()
+    {
+        $this->postJson('api/my_program_corners', ['listener_my_program_id' => $this->listener_my_program->id, 'name' => 'BBSリクエスト', 'listener_id' => $this->listener->id]);
+        $my_program_corner = MyProgramCorner::first();
+
+        $response1 = $this->putJson('api/my_program_corners/' . $my_program_corner->id, ['listener_my_program_id' => $this->listener_my_program->id, 'name' => '', 'listener_id' => $this->listener->id]);
+        $response1->assertStatus(422)
+            ->assertJsonValidationErrors([
+                'name' => [
+                    'マイ番組コーナー名を入力してください。'
+                ]
+            ]);
+
+        $response1 = $this->putJson('api/my_program_corners/' . $my_program_corner->id, ['listener_my_program_id' => $this->listener_my_program->id, 'name' => str_repeat('あ', 101), 'listener_id' => $this->listener->id]);
+        $response1->assertStatus(422)
+            ->assertJsonValidationErrors([
+                'name' => [
+                    '番組コーナー名は100文字以下で入力してください。'
+                ]
+            ]);
+
+        $my_program_corner = MyProgramCorner::first();
+        $this->assertEquals('BBSリクエスト', $my_program_corner->name);
+    }
+
+    /**
+     * @test
+     * App\Http\Controllers\MyProgramCornerController@update
+     */
+    public function 番組コーナー更新に失敗する（ログイン関連）()
+    {
+        $this->postJson('api/my_program_corners', ['listener_my_program_id' => $this->listener_my_program->id, 'name' => 'BBSリクエスト', 'listener_id' => $this->listener->id]);
+        $my_program_corner = MyProgramCorner::first();
+
+        $response = $this->putJson('api/my_program_corners/' . $my_program_corner->id, ['listener_my_program_id' => $this->listener_my_program->id, 'name' => 'ザワニュー', 'listener_id' => 11111111]);
+        $response->assertStatus(409)
+            ->assertJson([
+                'message' => 'ログインし直してください。'
+            ]);
+
+        $my_program_corner = MyProgramCorner::first();
+        $this->assertEquals('BBSリクエスト', $my_program_corner->name);
+    }
 }


### PR DESCRIPTION
## チケットへのリンク
https://trello.com/c/s53CErgb/303-%E3%80%90api%E3%80%91%E3%83%9E%E3%82%A4%E7%95%AA%E7%B5%84%E3%82%B3%E3%83%BC%E3%83%8A%E3%83%BC%E6%9B%B4%E6%96%B0api%E5%AE%9F%E8%A3%85
## やったこと

- マイ番組コーナー更新APIの実装

## やらないこと

## できるようになること

- マイ番組コーナーを更新できるようになる

## できなくなること

## 動作確認有無

- ログイン機能実装後Postmanにて動作確認

## 参考URL

## その他