### PR TITLE
マイ番組コーナー削除APIの実装

### DIFF
--- a/app/DataProviders/Repositories/MyProgramCornerRepository.php
+++ b/app/DataProviders/Repositories/MyProgramCornerRepository.php
@@ -77,4 +77,16 @@ class MyProgramCornerRepository
         $my_program_corner->name = $request->name;
         return $my_program_corner->save();
     }
+
+    /**
+     * マイ番組コーナー削除
+     *
+     * @param int $my_program_corner_id マイ番組コーナーID
+     * @return bool 削除できたかどうか
+     */
+    public function deleteMyProgramCorner(int $my_program_corner_id): bool
+    {
+        $my_program_corner = $this->my_program_corner::find($my_program_corner_id);
+        return $my_program_corner->delete();
+    }
 }

--- a/app/Http/Controllers/MyProgramCornerController.php
+++ b/app/Http/Controllers/MyProgramCornerController.php
@@ -98,4 +98,32 @@ class MyProgramCornerController extends Controller
             ], 409, [], JSON_UNESCAPED_UNICODE);
         }
     }
+
+    /**
+     * マイ番組コーナー削除（1コーナーのみ）
+     *
+     * @param Request $request getパラメーター
+     * @param int $my_program_corner_id マイ番組コーナーID
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function destroy(Request $request, int $my_program_corner_id)
+    {
+        $listener_id = (int) $request->input('listener');
+        if ($listener_id !== auth()->user()->id) {
+            return response()->json([
+                'message' => 'ログインし直してください。'
+            ], 409, [], JSON_UNESCAPED_UNICODE);
+        }
+
+        try {
+            $this->my_program_corner->deleteMyProgramCorner($my_program_corner_id);
+            return response()->json([
+                'message' => 'マイ番組コーナーが削除されました。'
+            ], 200, [], JSON_UNESCAPED_UNICODE);
+        } catch (\Throwable $th) {
+            return response()->json([
+                'message' => 'マイ番組コーナーの削除に失敗しました。'
+            ], 500, [], JSON_UNESCAPED_UNICODE);
+        }
+    }
 }

--- a/app/Services/Listener/MyProgramCornerService.php
+++ b/app/Services/Listener/MyProgramCornerService.php
@@ -75,4 +75,16 @@ class MyProgramCornerService
         $my_program_corner = $this->my_program_corner->updateMyProgramCorner($request, $my_program_corner_id);
         return $my_program_corner;
     }
+
+    /**
+     * マイ番組コーナー削除
+     *
+     * @param int $my_program_corner_id マイ番組コーナーID
+     * @return bool 削除できたかどうか
+     */
+    public function deleteMyProgramCorner(int $my_program_corner_id): bool
+    {
+        $is_deleted = $this->my_program_corner->deleteMyProgramCorner($my_program_corner_id);
+        return $is_deleted;
+    }
 }

--- a/tests/Feature/MyProgramCornerTest.php
+++ b/tests/Feature/MyProgramCornerTest.php
@@ -174,4 +174,23 @@ class MyProgramCornerTest extends TestCase
         $my_program_corner = MyProgramCorner::first();
         $this->assertEquals('BBSリクエスト', $my_program_corner->name);
     }
+
+    /**
+     * @test
+     * App\Http\Controllers\MyProgramCornerController@destroy
+     */
+    public function 番組コーナーを削除できる()
+    {
+        $this->postJson('api/my_program_corners', ['listener_my_program_id' => $this->listener_my_program->id, 'name' => 'BBSリクエスト', 'listener_id' => $this->listener->id]);
+        $program_corner = MyProgramCorner::first();
+
+        $response = $this->deleteJson('api/my_program_corners/' . $program_corner->id . '?listener=' . $this->listener->id);
+
+        $response->assertStatus(200)
+            ->assertJson([
+                'message' => 'マイ番組コーナーが削除されました。'
+            ]);
+
+        $this->assertEquals(0, MyProgramCorner::count());
+    }
 }

--- a/tests/Feature/MyProgramCornerTest.php
+++ b/tests/Feature/MyProgramCornerTest.php
@@ -185,10 +185,15 @@ class MyProgramCornerTest extends TestCase
         $program_corner = MyProgramCorner::first();
 
         $response = $this->deleteJson('api/my_program_corners/' . $program_corner->id . '?listener=' . $this->listener->id);
-
         $response->assertStatus(200)
             ->assertJson([
                 'message' => 'マイ番組コーナーが削除されました。'
+            ]);
+
+        $response = $this->deleteJson('api/my_program_corners/' . $program_corner->id . '?listener=100000');
+        $response->assertStatus(409)
+            ->assertJson([
+                'message' => 'ログインし直してください。'
             ]);
 
         $this->assertEquals(0, MyProgramCorner::count());


### PR DESCRIPTION
## チケットへのリンク
https://trello.com/c/uxwU2ZCN/304-%E3%80%90api%E3%80%91%E3%83%9E%E3%82%A4%E7%95%AA%E7%B5%84%E3%82%B3%E3%83%BC%E3%83%8A%E3%83%BC%E5%89%8A%E9%99%A4api%E5%AE%9F%E8%A3%85
## やったこと

- マイ番組コーナー削除APIの実装

## やらないこと

## できるようになること

- マイ番組コーナーを削除できる

## できなくなること

## 動作確認有無

- ログイン機能実装後Postmanにて動作確認

## 参考URL

## その他