### PR TITLE
番組コーナー個別取得APIの実装

### DIFF
--- a/app/DataProviders/Repositories/ProgramCornerRepository.php
+++ b/app/DataProviders/Repositories/ProgramCornerRepository.php
@@ -51,6 +51,17 @@ class ProgramCornerRepository
     }
 
     /**
+     * 個別の番組コーナー取得
+     * 
+     * @param int $program_corner_id 番組コーナーID
+     * @return ProgramCorner 番組コーナーデータ
+     */
+    public function getSingleProgramCorner(int $program_corner_id): ProgramCorner
+    {
+        return $this->program_corner::find($program_corner_id);
+    }
+
+    /**
      * 番組コーナー作成
      *
      * @param ProgramCornerRequest $request 番組コーナー作成リクエストデータ

--- a/app/Http/Controllers/ProgramCornerController.php
+++ b/app/Http/Controllers/ProgramCornerController.php
@@ -40,6 +40,26 @@ class ProgramCornerController extends Controller
     }
 
     /**
+     * 個別の番組コーナー取得
+     * 
+     * @param int $program_corner_id 番組コーナーID
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function show(int $program_corner_id)
+    {
+        try {
+            $program_corner = $this->program_corner->getSingleProgramCorner($program_corner_id);
+            return response()->json([
+                'program_corner' => $program_corner
+            ], 200, [], JSON_UNESCAPED_UNICODE);
+        } catch (\Throwable $th) {
+            return response()->json([
+                'message' => '番組コーナーの取得に失敗しました。'
+            ], 500, [], JSON_UNESCAPED_UNICODE);
+        }
+    }
+
+    /**
      * 番組コーナー作成
      *
      * @param ProgramCornerRequest $request 番組コーナー作成リクエストデータ

--- a/app/Services/Radio/ProgramCornerService.php
+++ b/app/Services/Radio/ProgramCornerService.php
@@ -52,6 +52,18 @@ class ProgramCornerService
     }
 
     /**
+     * 個別の番組コーナー取得
+     *
+     * @param int $program_corner_id 番組コーナーID
+     * @return ProgramCorner 番組コーナーデータ
+     */
+    public function getSingleProgramCorner(int $program_corner_id): ProgramCorner
+    {
+        $program_corner = $this->program_corner->getSingleProgramCorner($program_corner_id);
+        return $program_corner;
+    }
+
+    /**
      * 番組コーナー作成
      *
      * @param ProgramCornerRequest $request 番組コーナー作成リクエストデータ

--- a/tests/Feature/ProgramCornerTest.php
+++ b/tests/Feature/ProgramCornerTest.php
@@ -93,6 +93,25 @@ class ProgramCornerTest extends TestCase
 
     /**
      * @test
+     * App\Http\Controllers\ProgramCornerController@show
+     */
+    public function 個別の番組コーナーを取得できる()
+    {
+        $response = $this->postJson('api/program_corners', ['radio_program_id' => $this->radio_program->id, 'name' => '死んでもやめんじゃねーぞ']);
+        $program_corner = ProgramCorner::first();
+
+        $response = $this->getJson('api/program_corners/' . $program_corner->id);
+
+        $response->assertStatus(200)
+            ->assertJson([
+                'program_corner' => [
+                    'name' => '死んでもやめんじゃねーぞ'
+                ]
+            ]);
+    }
+
+    /**
+     * @test
      * App\Http\Controllers\ProgramCornerController@update
      */
     public function 番組コーナーを更新できる()


### PR DESCRIPTION
## チケットへのリンク
https://trello.com/c/vnYvoRyW/306-%E3%80%90api%E3%80%91%E7%95%AA%E7%B5%84%E3%82%B3%E3%83%BC%E3%83%8A%E3%83%BC%E5%80%8B%E5%88%A5%E5%8F%96%E5%BE%97api%E5%AE%9F%E8%A3%85-1pt
## やったこと

- 番組コーナー個別取得APIの実装

## やらないこと

## できるようになること

- 番組コーナーの個別情報を取得できる

## できなくなること

## 動作確認有無

- ログイン機能実装後Postmanにで動作確認

## 参考URL

## その他