### PR TITLE
マイ番組コーナー個別取得API実装

### DIFF
--- a/app/DataProviders/Repositories/MyProgramCornerRepository.php
+++ b/app/DataProviders/Repositories/MyProgramCornerRepository.php
@@ -51,6 +51,17 @@ class MyProgramCornerRepository
     }
 
     /**
+     * 個別のマイ番組コーナー取得
+     * 
+     * @param int $my_program_corner_id マイ番組コーナーID
+     * @return MyProgramCorner マイ番組コーナーデータ
+     */
+    public function getSingleMyProgramCorner(int $my_program_corner_id): MyProgramCorner
+    {
+        return $this->my_program_corner::find($my_program_corner_id);
+    }
+
+    /**
      * マイ番組作成
      *
      * @param MyProgramCornerRequest $request マイ番組作成リクエストデータ

--- a/app/Http/Controllers/MyProgramCornerController.php
+++ b/app/Http/Controllers/MyProgramCornerController.php
@@ -47,6 +47,26 @@ class MyProgramCornerController extends Controller
     }
 
     /**
+     * 個別のマイ番組コーナー取得
+     * 
+     * @param int $my_program_corner_id マイ番組コーナーID
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function show(int $my_program_corner_id)
+    {
+        try {
+            $my_program_corner = $this->my_program_corner->getSingleMyProgramCorner($my_program_corner_id);
+            return response()->json([
+                'my_program_corner' => $my_program_corner
+            ], 200, [], JSON_UNESCAPED_UNICODE);
+        } catch (\Throwable $th) {
+            return response()->json([
+                'message' => 'マイ番組コーナーの取得に失敗しました。'
+            ], 500, [], JSON_UNESCAPED_UNICODE);
+        }
+    }
+
+    /**
      * マイ番組コーナー作成
      *
      * @param MyProgramCornerRequest $request マイ番組コーナー作成リクエストデータ

--- a/app/Services/Listener/MyProgramCornerService.php
+++ b/app/Services/Listener/MyProgramCornerService.php
@@ -52,6 +52,19 @@ class MyProgramCornerService
     }
 
     /**
+     * 個別のマイ番組コーナー取得
+     *
+     * @param int $my_program_corner_id マイ番組コーナーID
+     * @return MyProgramCorner マイ番組コーナーデータ
+     */
+    public function getSingleMyProgramCorner(int $my_program_corner_id): MyProgramCorner
+    {
+        $my_program_corner = $this->my_program_corner->getSingleMyProgramCorner($my_program_corner_id);
+        return $my_program_corner;
+    }
+
+
+    /**
      * マイ番組コーナー作成
      * 
      * @param MyProgramCornerRequest $request マイ番組コーナー登録用のリクエストデータ

--- a/tests/Feature/MyProgramCornerTest.php
+++ b/tests/Feature/MyProgramCornerTest.php
@@ -110,6 +110,25 @@ class MyProgramCornerTest extends TestCase
 
     /**
      * @test
+     * App\Http\Controllers\MyProgramCornerController@show
+     */
+    public function 個別のマイラジオ番組を取得できる()
+    {
+        $this->postJson('api/my_program_corners', ['listener_my_program_id' => $this->listener_my_program->id, 'name' => 'BBSリクエスト', 'listener_id' => $this->listener->id]);
+        $my_program_corner = MyProgramCorner::first();
+
+        $response = $this->getJson('api/my_program_corners/' . $my_program_corner->id);
+
+        $response->assertStatus(200)
+            ->assertJson([
+                'my_program_corner' => [
+                    'name' => 'BBSリクエスト',
+                ]
+            ]);
+    }
+
+    /**
+     * @test
      * App\Http\Controllers\MyProgramCornerController@update
      */
     public function 番組コーナーを更新できる()


### PR DESCRIPTION
## チケットへのリンク
https://trello.com/c/cL8QoWjZ/307-%E3%80%90api%E3%80%91%E3%83%9E%E3%82%A4%E7%95%AA%E7%B5%84%E3%82%B3%E3%83%BC%E3%83%8A%E3%83%BC%E5%80%8B%E5%88%A5%E5%8F%96%E5%BE%97api%E5%AE%9F%E8%A3%85-1pt
## やったこと

- マイ番組コーナー個別取得APIの実装

## やらないこと

## できるようになること

- マイ番組コーナーの個別の情報を取得できる

## できなくなること

## 動作確認有無

- ログイン機能実装後Postmanにて動作確認

## 参考URL

## その他