### PR TITLE
投稿API実装

### DIFF
--- a/app/DataProviders/Models/ListenerMessage.php
+++ b/app/DataProviders/Models/ListenerMessage.php
@@ -4,8 +4,76 @@ namespace App\DataProviders\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class ListenerMessage extends Model
 {
     use HasFactory;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'radio_program_id',
+        'program_corner_id',
+        'listener_my_program_id',
+        'my_program_corner_id',
+        'listener_id',
+        'subject',
+        'content',
+        'radio_name',
+        'posted_at'
+    ];
+
+    /**
+     * ラジオ番組用リレーション
+     * 
+     * @return BelongsTo
+     */
+    public function RadioProgram(): BelongsTo
+    {
+        return $this->belongsTo(RadioProgram::class);
+    }
+
+    /**
+     * ラジオ番組コーナー用リレーション
+     * 
+     * @return BelongsTo
+     */
+    public function ProgramCorner(): BelongsTo
+    {
+        return $this->belongsTo(ProgramCorner::class);
+    }
+
+    /**
+     * マイ番組用リレーション
+     * 
+     * @return BelongsTo
+     */
+    public function ListenerMyProgram(): BelongsTo
+    {
+        return $this->belongsTo(ListenerMyProgram::class);
+    }
+
+    /**
+     * マイ番組コーナー用リレーション
+     * 
+     * @return BelongsTo
+     */
+    public function MyProgramCorner(): BelongsTo
+    {
+        return $this->belongsTo(MyProgramCorner::class);
+    }
+
+    /**
+     * リスナー用リレーション
+     * 
+     * @return BelongsTo
+     */
+    public function Listener(): BelongsTo
+    {
+        return $this->belongsTo(Listener::class);
+    }
 }

--- a/app/DataProviders/Models/ListenerMessage.php
+++ b/app/DataProviders/Models/ListenerMessage.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\DataProviders\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class ListenerMessage extends Model
+{
+    use HasFactory;
+}

--- a/app/DataProviders/Models/ListenerMyProgram.php
+++ b/app/DataProviders/Models/ListenerMyProgram.php
@@ -33,6 +33,16 @@ class ListenerMyProgram extends Model
     }
 
     /**
+     * 投稿メッセージ用リレーション
+     * 
+     * @return HasMany
+     */
+    public function ListenerMessages(): HasMany
+    {
+        return $this->hasMany(ListenerMessage::class);
+    }
+
+    /**
      * リスナー用リレーション
      * 
      * @return BelongsTo

--- a/app/DataProviders/Models/MyProgramCorner.php
+++ b/app/DataProviders/Models/MyProgramCorner.php
@@ -4,6 +4,7 @@ namespace App\DataProviders\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class MyProgramCorner extends Model
@@ -19,6 +20,16 @@ class MyProgramCorner extends Model
         'name',
         'listener_my_program_id'
     ];
+
+    /**
+     * 投稿メッセージ用リレーション
+     * 
+     * @return HasMany
+     */
+    public function ListenerMessages(): HasMany
+    {
+        return $this->hasMany(ListenerMessage::class);
+    }
 
     /**
      * マイ番組用リレーション

--- a/app/DataProviders/Models/ProgramCorner.php
+++ b/app/DataProviders/Models/ProgramCorner.php
@@ -4,6 +4,7 @@ namespace App\DataProviders\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class ProgramCorner extends Model
@@ -19,6 +20,16 @@ class ProgramCorner extends Model
         'name',
         'radio_program_id'
     ];
+
+    /**
+     * 投稿メッセージ用リレーション
+     * 
+     * @return HasMany
+     */
+    public function ListenerMessages(): HasMany
+    {
+        return $this->hasMany(ListenerMessage::class);
+    }
 
     /**
      * ラジオ番組用リレーション

--- a/app/DataProviders/Models/RadioProgram.php
+++ b/app/DataProviders/Models/RadioProgram.php
@@ -31,6 +31,16 @@ class RadioProgram extends Model
     }
 
     /**
+     * 投稿メッセージ用リレーション
+     * 
+     * @return HasMany
+     */
+    public function ListenerMessages(): HasMany
+    {
+        return $this->hasMany(ListenerMessage::class);
+    }
+
+    /**
      * ラジオ局用リレーション
      * 
      * @return BelongsTo

--- a/app/DataProviders/Repositories/ListenerRepository.php
+++ b/app/DataProviders/Repositories/ListenerRepository.php
@@ -13,7 +13,10 @@
 namespace App\DataProviders\Repositories;
 
 use App\DataProviders\Models\Listener;
+use App\DataProviders\Models\ListenerMessage;
 use App\Http\Requests\ListenerRequest;
+use App\Http\Requests\ListenerMessageRequest;
+use Carbon\Carbon;
 use Illuminate\Support\Facades\Hash;
 
 /**
@@ -30,14 +33,21 @@ class ListenerRepository
     private $listener;
 
     /**
+     * @var ListenerMessage $listener_message ListenerMessageインスタンス
+     */
+    private $listener_message;
+
+    /**
      * コンストラクタ
      *
      * @param Listener $listener ListenerModel
+     * @param ListenerMessage $listener_message ListenerMessageModel
      * @return void
      */
-    public function __construct(Listener $listener)
+    public function __construct(Listener $listener, ListenerMessage $listener_message)
     {
         $this->listener = $listener;
+        $this->listener_message = $listener_message;
     }
 
     /**
@@ -75,5 +85,27 @@ class ListenerRepository
     {
         return $this->listener::where('id', $listener_id)
             ->first();
+    }
+
+    /**
+     * 投稿メッセージ保存
+     * 
+     * @param ListenerMessageRequest $request メッセージ投稿用のリクエストデータ
+     * @param int $listener_id リスナーID
+     * @return void
+     */
+    public function storeListenerMyProgram(ListenerMessageRequest $request, int $listener_id)
+    {
+        $this->listener_message::create([
+            'radio_program_id' => $request->radio_program_id ? $request->radio_program_id : null,
+            'program_corner_id' => $request->program_corner_id ? $request->program_corner_id : null,
+            'listener_my_program_id' => $request->listener_my_program_id ? $request->listener_my_program_id : null,
+            'my_program_corner_id' => $request->my_program_corner_id ? $request->my_program_corner_id : null,
+            'listener_id' => $listener_id,
+            'subject' => $request->subject ? $request->subject : null,
+            'content' => $request->content,
+            'radio_name' => $request->radio_name ? $request->radio_name : null,
+            'posted_at' => Carbon::now()
+        ]);
     }
 }

--- a/app/Http/Controllers/ListenerMessageController.php
+++ b/app/Http/Controllers/ListenerMessageController.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\ListenerMessageRequest;
+use App\Services\Listener\ListenerService;
+
+class ListenerMessageController extends Controller
+{
+    /**
+     * @var ListenerService $listener ListenerServiceインスタンス
+     */
+    private $listener;
+
+    public function __construct(ListenerService $listener)
+    {
+        $this->listener = $listener;
+    }
+
+    /**
+     * メッセージ投稿
+     * 
+     * @param ListenerMessageRequest $request メッセージ投稿用のリクエストデータ
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function store(ListenerMessageRequest $request)
+    {
+        try {
+            $this->listener->storeListenerMyProgram($request, auth()->user()->id);
+            // $this->listener->sendEmailToRadioProgram($request, auth()->user()->id);
+            return response()->json([
+                'message' => 'メッセージが投稿されました。'
+            ], 201, [], JSON_UNESCAPED_UNICODE);
+        } catch (\Throwable $th) {
+            return response()->json([
+                'message' => 'メッセージの投稿に失敗しました。'
+            ], 409, [], JSON_UNESCAPED_UNICODE);
+        }
+    }
+}

--- a/app/Http/Controllers/ListenerMessageController.php
+++ b/app/Http/Controllers/ListenerMessageController.php
@@ -27,7 +27,7 @@ class ListenerMessageController extends Controller
     {
         try {
             $this->listener->storeListenerMyProgram($request, auth()->user()->id);
-            // $this->listener->sendEmailToRadioProgram($request, auth()->user()->id);
+            $this->listener->sendEmailToRadioProgram($request, auth()->user()->id);
             return response()->json([
                 'message' => 'メッセージが投稿されました。'
             ], 201, [], JSON_UNESCAPED_UNICODE);

--- a/app/Http/Requests/ListenerMessageRequest.php
+++ b/app/Http/Requests/ListenerMessageRequest.php
@@ -25,17 +25,37 @@ class ListenerMessageRequest extends FormRequest
     public function rules()
     {
         if ($this->input('radio_program_id')) {
-            return [
-                'listener_id' => 'required',
-                'content' => 'required',
-                'radio_program_id' => 'required'
-            ];
+            if ($this->input('program_corner_id')) {
+                return [
+                    'listener_id' => 'required',
+                    'content' => 'required',
+                    'radio_program_id' => 'required',
+                    'program_corner_id' => 'required'
+                ];
+            } else {
+                return [
+                    'listener_id' => 'required',
+                    'content' => 'required',
+                    'radio_program_id' => 'required',
+                    'subject' => 'required'
+                ];
+            }
         } else {
-            return [
-                'listener_id' => 'required',
-                'content' => 'required',
-                'listener_my_program_id' => 'required',
-            ];
+            if ($this->input('my_program_corner_id')) {
+                return [
+                    'listener_id' => 'required',
+                    'content' => 'required',
+                    'listener_my_program_id' => 'required',
+                    'my_program_corner_id' => 'required'
+                ];
+            } else {
+                return [
+                    'listener_id' => 'required',
+                    'content' => 'required',
+                    'listener_my_program_id' => 'required',
+                    'subject' => 'required'
+                ];
+            }
         }
     }
 
@@ -43,8 +63,11 @@ class ListenerMessageRequest extends FormRequest
     {
         return [
             'content.required' => '本文を入力してください。',
-            'radio_program_id.required' => '番組を入力してください。',
-            'listener_my_program_id.required' => '番組を入力してください。',
+            'radio_program_id.required' => '番組を選択してください。',
+            'listener_my_program_id.required' => '番組を選択してください。',
+            'program_corner_id.required' => 'コーナーを選択してください。',
+            'my_program_corner_id.required' => 'コーナーを選択してください。',
+            'subject.required' => '件名を入力してください。'
         ];
     }
 

--- a/app/Http/Requests/ListenerMessageRequest.php
+++ b/app/Http/Requests/ListenerMessageRequest.php
@@ -27,14 +27,12 @@ class ListenerMessageRequest extends FormRequest
         if ($this->input('radio_program_id')) {
             if ($this->input('program_corner_id')) {
                 return [
-                    'listener_id' => 'required',
                     'content' => 'required',
                     'radio_program_id' => 'required',
                     'program_corner_id' => 'required'
                 ];
             } else {
                 return [
-                    'listener_id' => 'required',
                     'content' => 'required',
                     'radio_program_id' => 'required',
                     'subject' => 'required'
@@ -43,14 +41,12 @@ class ListenerMessageRequest extends FormRequest
         } else {
             if ($this->input('my_program_corner_id')) {
                 return [
-                    'listener_id' => 'required',
                     'content' => 'required',
                     'listener_my_program_id' => 'required',
                     'my_program_corner_id' => 'required'
                 ];
             } else {
                 return [
-                    'listener_id' => 'required',
                     'content' => 'required',
                     'listener_my_program_id' => 'required',
                     'subject' => 'required'

--- a/app/Http/Requests/ListenerMessageRequest.php
+++ b/app/Http/Requests/ListenerMessageRequest.php
@@ -65,9 +65,9 @@ class ListenerMessageRequest extends FormRequest
             'content.required' => '本文を入力してください。',
             'radio_program_id.required' => '番組を選択してください。',
             'listener_my_program_id.required' => '番組を選択してください。',
-            'program_corner_id.required' => 'コーナーを選択してください。',
-            'my_program_corner_id.required' => 'コーナーを選択してください。',
-            'subject.required' => '件名を入力してください。'
+            'program_corner_id.required' => 'コーナーを選択するか件名を入力してください。',
+            'my_program_corner_id.required' => 'コーナーを選択するか件名を入力してください。',
+            'subject.required' => 'コーナーを選択するか件名を入力してください。'
         ];
     }
 

--- a/app/Http/Requests/ListenerMessageRequest.php
+++ b/app/Http/Requests/ListenerMessageRequest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Http\Exceptions\HttpResponseException;
+
+class ListenerMessageRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        if ($this->input('radio_program_id')) {
+            return [
+                'listener_id' => 'required',
+                'content' => 'required',
+                'radio_program_id' => 'required'
+            ];
+        } else {
+            return [
+                'listener_id' => 'required',
+                'content' => 'required',
+                'listener_my_program_id' => 'required',
+            ];
+        }
+    }
+
+    public function messages()
+    {
+        return [
+            'content.required' => '本文を入力してください。',
+            'radio_program_id.required' => '番組を入力してください。',
+            'listener_my_program_id.required' => '番組を入力してください。',
+        ];
+    }
+
+    protected function failedValidation($validator)
+    {
+        $response = response()->json([
+            'status' => 422,
+            'errors' => $validator->errors(),
+        ], 422);
+
+        throw new HttpResponseException($response);
+    }
+}

--- a/app/Mail/ListenerMessageMail.php
+++ b/app/Mail/ListenerMessageMail.php
@@ -12,13 +12,100 @@ class ListenerMessageMail extends Mailable
     use Queueable, SerializesModels;
 
     /**
+     * @var string|null $corner コーナー（件名）
+     */
+    private $corner;
+
+    /**
+     * @var string|null $full_name 本名
+     */
+    private $full_name;
+
+    /**
+     * @var string|null $full_name_kana 本名かな
+     */
+    private $full_name_kana;
+
+    /**
+     * @var string|null $radio_name ラジオネーム
+     */
+    private $radio_name;
+
+    /**
+     * @var int|null $post_code 郵便番号
+     */
+    private $post_code;
+
+    /**
+     * @var string|null $prefecture 都道府県
+     */
+    private $prefecture;
+
+    /**
+     * @var string|null $city 市区町村
+     */
+    private $city;
+
+    /**
+     * @var string|null $house_number 住所
+     */
+    private $house_number;
+
+    /**
+     * @var string|null $tel 電話番号
+     */
+    private $tel;
+
+    /**
+     * @var string|null $email メールアドレス
+     */
+    private $email;
+
+    /**
+     * @var string|null $content 本文
+     */
+    private $content;
+
+    /**
      * Create a new message instance.
      *
+     * @param string|null $corner コーナー（件名）
+     * @param string|null $full_name 本名
+     * @param string|null $full_name_kana 本名かな
+     * @param string|null $radio_name ラジオネーム
+     * @param int|null    $post_code 郵便番号
+     * @param string|null $prefecture 都道府県
+     * @param string|null $city 市区町村
+     * @param string|null $house_number 住所
+     * @param string|null $tel 電話番号
+     * @param string|null $email メールアドレス
+     * @param string|null $content 本文
      * @return void
      */
-    public function __construct()
-    {
-        //
+    public function __construct(
+        string|null $corner,
+        string|null $full_name,
+        string|null $full_name_kana,
+        string|null $radio_name,
+        int|null    $post_code,
+        string|null $prefecture,
+        string|null $city,
+        string|null $house_number,
+        string|null $tel,
+        string|null $email,
+        string|null $content
+    ) {
+        $this->corner = $corner;
+        $this->full_name = $full_name;
+        $this->full_name_kana = $full_name_kana;
+        $this->radio_name = $radio_name;
+        $this->post_code = $post_code;
+        $this->prefecture = $prefecture;
+        $this->city = $city;
+        $this->house_number = $house_number;
+        $this->tel = $tel;
+        $this->email = $email;
+        $this->content = $content;
     }
 
     /**
@@ -28,9 +115,20 @@ class ListenerMessageMail extends Mailable
      */
     public function build()
     {
-        return $this->from('test@example.com')
-            ->subject('テスト')
+        return $this->from(config('mail.from.address'))
+            ->subject($this->corner)
             ->view('email.listener_message')
-            ->with(['test' => 'テスト']);
+            ->with([
+                'full_name' => $this->full_name,
+                'full_name_kana' => $this->full_name_kana,
+                'radio_name' => $this->radio_name,
+                'post_code' => $this->post_code,
+                'prefecture' => $this->prefecture,
+                'city' => $this->city,
+                'house_number' => $this->house_number,
+                'tel' => $this->tel,
+                'email' => $this->email,
+                'content' => $this->content,
+            ]);
     }
 }

--- a/app/Mail/ListenerMessageMail.php
+++ b/app/Mail/ListenerMessageMail.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Mail\Mailable;
+use Illuminate\Queue\SerializesModels;
+
+class ListenerMessageMail extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    /**
+     * Create a new message instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Build the message.
+     *
+     * @return $this
+     */
+    public function build()
+    {
+        return $this->from('test@example.com')
+            ->subject('テスト')
+            ->view('email.listener_message')
+            ->with(['test' => 'テスト']);
+    }
+}

--- a/app/Services/Listener/ListenerService.php
+++ b/app/Services/Listener/ListenerService.php
@@ -12,10 +12,16 @@
 
 namespace App\Services\Listener;
 
+use Illuminate\Support\Facades\Mail;
 use App\DataProviders\Models\Listener;
+use App\DataProviders\Repositories\RadioProgramRepository;
+use App\DataProviders\Repositories\ProgramCornerRepository;
+use App\DataProviders\Repositories\ListenerMyProgramRepository;
+use App\DataProviders\Repositories\MyProgramCornerRepository;
 use App\DataProviders\Repositories\ListenerRepository;
 use App\Http\Requests\ListenerRequest;
 use App\Http\Requests\ListenerMessageRequest;
+use App\Mail\ListenerMessageMail;
 
 /**
  * リスナー用のサービスクラス
@@ -26,18 +32,59 @@ use App\Http\Requests\ListenerMessageRequest;
 class ListenerService
 {
     /**
+     * @var RadioProgramRepository $radio_program RadioProgramRepositoryインスタンス
+     */
+    private $radio_program;
+
+    // /**
+    //  * @var ProgramCornerRepository $program_corner ProgramCornerRepositoryインスタンス
+    //  */
+    // private $program_corner;
+
+    /**
+     * @var ListenerMyProgramRepository $listener_my_program ListenerMyProgramRepositoryインスタンス
+     */
+    private $listener_my_program;
+
+    // /**
+    //  * @var MyProgramCornerRepository $my_program_corner MyProgramCornerRepositoryインスタンス
+    //  */
+    // private $my_program_corner;
+
+    /**
      * @var ListenerRepository $listener ListenerRepositoryインスタンス
      */
     private $listener;
 
     /**
+     * @var ListenerMessageMail $listener_message_mail ListenerMessageMailインスタンス
+     */
+    private $listener_message_mail;
+
+    /**
      * コンストラクタ
      *
+     * @param RadioProgramRepository $radio_program RadioProgramRepositoryインスタンス
+    //  * @param ProgramCornerRepository $program_corner ProgramCornerRepositoryインスタンス
+     * @param ListenerMyProgramRepository $listener_my_program ListenerMyProgramRepositoryインスタンス
+    //  * @param MyProgramCornerRepository $my_program_corner MyProgramCornerRepositoryインスタンス
      * @param ListenerRepository $listener ListenerRepositoryインスタンス
+     * @param ListenerMessageMail $listener_message_mail ListenerMessageMailインスタンス
      */
-    public function __construct(ListenerRepository $listener)
-    {
+    public function __construct(
+        RadioProgramRepository $radio_program,
+        // ProgramCornerRepository $program_corner,
+        ListenerMyProgramRepository $listener_my_program,
+        // MyProgramCornerRepository $my_program_corner,
+        ListenerRepository $listener,
+        ListenerMessageMail $listener_message_mail
+    ) {
+        $this->radio_program = $radio_program;
+        // $this->program_corner = $program_corner;
+        $this->listener_my_program = $listener_my_program;
+        // $this->my_program_corner = $my_program_corner;
         $this->listener = $listener;
+        $this->listener_message_mail = $listener_message_mail;
     }
 
     /**
@@ -85,5 +132,12 @@ class ListenerService
      */
     public function sendEmailToRadioProgram(ListenerMessageRequest $request, int $listener_id)
     {
+        $programData = [];
+        if ($request->radio_program_id) {
+            $programData['email'] = $this->radio_program->getSingleRadioProgram($request->radio_program_id)->email;
+        } else {
+            $programData['email'] = $this->listener_my_program->getSingleListenerMyProgram($listener_id, $request->listener_my_program_id)->email;
+        }
+        Mail::to('test@example.com')->send($this->listener_message_mail);
     }
 }

--- a/app/Services/Listener/ListenerService.php
+++ b/app/Services/Listener/ListenerService.php
@@ -15,6 +15,7 @@ namespace App\Services\Listener;
 use App\DataProviders\Models\Listener;
 use App\DataProviders\Repositories\ListenerRepository;
 use App\Http\Requests\ListenerRequest;
+use App\Http\Requests\ListenerMessageRequest;
 
 /**
  * リスナー用のサービスクラス
@@ -61,5 +62,28 @@ class ListenerService
     {
         $listener = $this->listener->getSingleListener($listener_id);
         return $listener;
+    }
+
+    /**
+     * 投稿メッセージをDBに保存
+     * 
+     * @param ListenerMessageRequest $request メッセージ投稿用のリクエストデータ
+     * @param int $listener_id リスナーID
+     * @return void
+     */
+    public function storeListenerMyProgram(ListenerMessageRequest $request, int $listener_id)
+    {
+        $this->listener->storeListenerMyProgram($request, $listener_id);
+    }
+
+    /**
+     * 投稿メッセージを投稿
+     * 
+     * @param ListenerMessageRequest $request メッセージ投稿用のリクエストデータ
+     * @param int $listener_id リスナーID
+     * @return void
+     */
+    public function sendEmailToRadioProgram(ListenerMessageRequest $request, int $listener_id)
+    {
     }
 }

--- a/database/factories/DataProviders/Models/ListenerFactory.php
+++ b/database/factories/DataProviders/Models/ListenerFactory.php
@@ -31,7 +31,7 @@ class ListenerFactory extends Factory
             'city' => $this->faker->city,
             'house_number' => $this->faker->streetAddress,
             'tel' => $this->faker->phoneNumber,
-            'email' => $this->faker->email,
+            'email' => $this->faker->safeEmail(),
             'email_verified_at' => now(),
             'password' => Hash::make('password123')
         ];

--- a/database/migrations/2022_04_22_221514_create_listener_messages_table.php
+++ b/database/migrations/2022_04_22_221514_create_listener_messages_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('listener_messages', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('radio_program_id')->nullable()->nullOnDelete()->constrained('radio_programs');
+            $table->foreignId('program_corner_id')->nullable()->nullOnDelete()->constrained('program_corners');
+            $table->foreignId('listener_my_program_id')->nullable()->nullOnDelete()->constrained('listener_my_programs');
+            $table->foreignId('my_program_corner_id')->nullable()->nullOnDelete()->constrained('my_program_corners');
+            $table->foreignId('listener_id')->nullOnDelete('cascade')->constrained('listeners');
+            $table->string('subject');
+            $table->string('content');
+            $table->string('radio_name');
+            $table->datetime('posted_at');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('listener_messages');
+    }
+};

--- a/database/migrations/2022_04_22_221514_create_listener_messages_table.php
+++ b/database/migrations/2022_04_22_221514_create_listener_messages_table.php
@@ -20,10 +20,10 @@ return new class extends Migration
             $table->foreignId('listener_my_program_id')->nullable()->nullOnDelete()->constrained('listener_my_programs');
             $table->foreignId('my_program_corner_id')->nullable()->nullOnDelete()->constrained('my_program_corners');
             $table->foreignId('listener_id')->nullOnDelete('cascade')->constrained('listeners');
-            $table->string('subject');
+            $table->string('subject')->nullable();
             $table->string('content');
-            $table->string('radio_name');
-            $table->datetime('posted_at');
+            $table->string('radio_name')->nullable();
+            $table->datetime('posted_at')->nullable();
             $table->timestamps();
         });
     }

--- a/resources/views/email/listener_message.blade.php
+++ b/resources/views/email/listener_message.blade.php
@@ -1,3 +1,4 @@
+<p>{{ $prefecture }}</p>
 <p>RN: {{ $radio_name }}</p>
 <div>
     {{ $content }}
@@ -7,7 +8,7 @@
     <p>----------------------------------------------------------------</p>
     <p>〒{{ $post_code }}</p>
     <p>住所:{{ $prefecture }}　{{ $city }}　{{ $house_number }}</p>
-    <p>本名:{{ $last_name}}　{{ $first_name }}（{{ $last_name_kana}}　{{ $first_name_kana }}）</p>
+    <p>本名:{{ $full_name}}（{{ $full_name_kana}}）</p>
     <p>電話番号:{{ $tel }}</p>
     <p>メールアドレス:{{ $email }}</p>
 </div>

--- a/resources/views/email/listener_message.blade.php
+++ b/resources/views/email/listener_message.blade.php
@@ -1,0 +1,13 @@
+<p>RN: {{ $radio_name }}</p>
+<div>
+    {{ $content }}
+</div>
+
+<div>
+    <p>----------------------------------------------------------------</p>
+    <p>〒{{ $post_code }}</p>
+    <p>住所:{{ $prefecture }}　{{ $city }}　{{ $house_number }}</p>
+    <p>本名:{{ $last_name}}　{{ $first_name }}（{{ $last_name_kana}}　{{ $first_name_kana }}）</p>
+    <p>電話番号:{{ $tel }}</p>
+    <p>メールアドレス:{{ $email }}</p>
+</div>

--- a/routes/api.php
+++ b/routes/api.php
@@ -32,5 +32,5 @@ Route::group(['middleware' => 'auth:sanctum'], function () {
     Route::apiResource('message_templates', MessageTemplateController::class);
     Route::apiResource('listener_my_programs', ListenerMyProgramController::class);
     Route::apiResource('my_program_corners', MyProgramCornerController::class);
-    Route::apiResource('listener_messages', ListenerMessageController::class);
 });
+Route::apiResource('listener_messages', ListenerMessageController::class);

--- a/routes/api.php
+++ b/routes/api.php
@@ -32,5 +32,5 @@ Route::group(['middleware' => 'auth:sanctum'], function () {
     Route::apiResource('message_templates', MessageTemplateController::class);
     Route::apiResource('listener_my_programs', ListenerMyProgramController::class);
     Route::apiResource('my_program_corners', MyProgramCornerController::class);
+    Route::apiResource('listener_messages', ListenerMessageController::class);
 });
-Route::apiResource('listener_messages', ListenerMessageController::class);

--- a/routes/api.php
+++ b/routes/api.php
@@ -8,6 +8,7 @@ use App\Http\Controllers\ProgramCornerController;
 use App\Http\Controllers\MessageTemplateController;
 use App\Http\Controllers\ListenerMyProgramController;
 use App\Http\Controllers\MyProgramCornerController;
+use App\Http\Controllers\ListenerMessageController;
 use Illuminate\Support\Facades\Route;
 
 /*
@@ -31,4 +32,5 @@ Route::group(['middleware' => 'auth:sanctum'], function () {
     Route::apiResource('message_templates', MessageTemplateController::class);
     Route::apiResource('listener_my_programs', ListenerMyProgramController::class);
     Route::apiResource('my_program_corners', MyProgramCornerController::class);
+    Route::apiResource('listener_messages', ListenerMessageController::class);
 });

--- a/tests/Feature/ListenerMessageTest.php
+++ b/tests/Feature/ListenerMessageTest.php
@@ -1,0 +1,261 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\DataProviders\Models\ListenerMessage;
+use App\DataProviders\Models\RadioStation;
+use App\DataProviders\Models\RadioProgram;
+use App\DataProviders\Models\ProgramCorner;
+use App\DataProviders\Models\ListenerMyProgram;
+use App\DataProviders\Models\MyProgramCorner;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ListenerMessageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function setup(): void
+    {
+        parent::setUp();
+
+        $this->listener = $this->loginAsListener();
+
+        $this->postJson('api/radio_stations', ['name' => 'テスト局']);
+        $this->radio_station = RadioStation::first();
+        $this->postJson('api/radio_programs', ['radio_station_id' => $this->radio_station->id, 'name' => 'テスト番組', 'email' => 'test@example.com']);
+        $this->radio_program = RadioProgram::first();
+        $this->postJson('api/program_corners', ['radio_program_id' => $this->radio_program->id, 'name' => '死んでもやめんじゃねーぞ']);
+        $this->program_corner = ProgramCorner::first();
+
+        $this->postJson('api/listener_my_programs', ['program_name' => 'テストマイ番組', 'email' => 'test@example.com']);
+        $this->listener_my_program = ListenerMyProgram::first();
+        $this->postJson('api/my_program_corners', ['listener_my_program_id' => $this->listener_my_program->id, 'name' => 'BBSリクエスト', 'listener_id' => $this->listener->id]);
+        $this->my_program_corner = MyProgramCorner::first();
+    }
+
+    /**
+     * @test
+     * App\Http\Controllers\ListenerMessageController@store
+     */
+    public function ラジオ番組にメッセージが投稿できる（コーナー指定）()
+    {
+        $response = $this->postJson('api/listener_messages', [
+            'radio_program_id' => $this->radio_program->id,
+            'program_corner_id' => $this->program_corner->id,
+            'listener_id' => $this->listener->id,
+            'content' => 'こんにちは。こんばんは。',
+        ]);
+
+        $response->assertStatus(201)
+            ->assertJson([
+                'message' => 'メッセージが投稿されました。'
+            ]);
+
+        $listener_message = ListenerMessage::first();
+        $this->assertEquals($this->radio_program->id, $listener_message->radio_program_id);
+        $this->assertEquals($this->program_corner->id, $listener_message->program_corner_id);
+        $this->assertEquals($this->listener->id, $listener_message->listener_id);
+        $this->assertEquals('こんにちは。こんばんは。', $listener_message->content);
+        $this->assertEquals('テスト番組', $listener_message->RadioProgram->name);
+        $this->assertEquals('死んでもやめんじゃねーぞ', $listener_message->ProgramCorner->name);
+    }
+
+    /**
+     * @test
+     * App\Http\Controllers\ListenerMessageController@store
+     */
+    public function ラジオ番組にメッセージが投稿できる（コーナー指定なし）()
+    {
+        $response = $this->postJson('api/listener_messages', [
+            'radio_program_id' => $this->radio_program->id,
+            'listener_id' => $this->listener->id,
+            'subject' => 'ふつおた',
+            'content' => 'こんにちは。こんばんは。',
+            'radio_name' => 'ハイキングベアー'
+        ]);
+
+        $response->assertStatus(201)
+            ->assertJson([
+                'message' => 'メッセージが投稿されました。'
+            ]);
+
+        $listener_message = ListenerMessage::first();
+        $this->assertEquals($this->radio_program->id, $listener_message->radio_program_id);
+        $this->assertEquals('ふつおた', $listener_message->subject);
+        $this->assertEquals($this->listener->id, $listener_message->listener_id);
+        $this->assertEquals('こんにちは。こんばんは。', $listener_message->content);
+        $this->assertEquals('テスト番組', $listener_message->RadioProgram->name);
+    }
+
+    /**
+     * @test
+     * App\Http\Controllers\ListenerMessageController@store
+     */
+    public function マイラジオ番組にメッセージが投稿できる（コーナー指定）()
+    {
+        $response = $this->postJson('api/listener_messages', [
+            'listener_my_program_id' => $this->listener_my_program->id,
+            'my_program_corner_id' => $this->my_program_corner->id,
+            'listener_id' => $this->listener->id,
+            'content' => 'こんにちは。こんばんは。',
+            'radio_name' => 'ハイキングベアー'
+        ]);
+
+        $response->assertStatus(201)
+            ->assertJson([
+                'message' => 'メッセージが投稿されました。'
+            ]);
+
+        $listener_message = ListenerMessage::first();
+        $this->assertEquals($this->listener_my_program->id, $listener_message->listener_my_program_id);
+        $this->assertEquals($this->my_program_corner->id, $listener_message->my_program_corner_id);
+        $this->assertEquals($this->listener->id, $listener_message->listener_id);
+        $this->assertEquals('こんにちは。こんばんは。', $listener_message->content);
+        $this->assertEquals('テストマイ番組', $listener_message->ListenerMyProgram->program_name);
+        $this->assertEquals('BBSリクエスト', $listener_message->MyProgramCorner->name);
+    }
+
+    /**
+     * @test
+     * App\Http\Controllers\ListenerMessageController@store
+     */
+    public function マイラジオ番組にメッセージが投稿できる（コーナー指定なし）()
+    {
+        $response = $this->postJson('api/listener_messages', [
+            'listener_my_program_id' => $this->listener_my_program->id,
+            'listener_id' => $this->listener->id,
+            'subject' => 'ふつおた',
+            'content' => 'こんにちは。こんばんは。',
+        ]);
+
+        $response->assertStatus(201)
+            ->assertJson([
+                'message' => 'メッセージが投稿されました。'
+            ]);
+
+        $listener_message = ListenerMessage::first();
+        $this->assertEquals($this->listener_my_program->id, $listener_message->listener_my_program_id);
+        $this->assertEquals($this->listener->id, $listener_message->listener_id);
+        $this->assertEquals('こんにちは。こんばんは。', $listener_message->content);
+        $this->assertEquals('テストマイ番組', $listener_message->ListenerMyProgram->program_name);
+    }
+
+    /**
+     * @test
+     * App\Http\Controllers\ListenerMessageController@store
+     */
+    public function ラジオ番組へのメッセージ投稿に失敗する（番組関連）()
+    {
+        $response = $this->postJson('api/listener_messages', [
+            'my_program_corner_id' => $this->my_program_corner->id,
+            'listener_id' => $this->listener->id,
+            'content' => 'こんにちは。こんばんは。',
+        ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors([
+                'listener_my_program_id' => [
+                    '番組を選択してください。'
+                ]
+            ]);
+
+        $this->assertEquals(0, ListenerMessage::count());
+    }
+
+    /**
+     * @test
+     * App\Http\Controllers\ListenerMessageController@store
+     */
+    public function ラジオ番組へのメッセージ投稿に失敗する（コーナー関連）()
+    {
+        $response1 = $this->postJson('api/listener_messages', [
+            'radio_program_id' => $this->radio_program->id,
+            'listener_id' => $this->listener->id,
+            'content' => 'こんにちは。こんばんは。',
+        ]);
+
+        $response1->assertStatus(422)
+            ->assertJsonValidationErrors([
+                'subject' => [
+                    'コーナーを選択するか件名を入力してください。'
+                ]
+            ]);
+
+        $response2 = $this->postJson('api/listener_messages', [
+            'listener_my_program_id' => $this->listener_my_program->id,
+            'listener_id' => $this->listener->id,
+            'content' => 'こんにちは。こんばんは。',
+        ]);
+
+        $response2->assertStatus(422)
+            ->assertJsonValidationErrors([
+                'subject' => [
+                    'コーナーを選択するか件名を入力してください。'
+                ]
+            ]);
+
+        $this->assertEquals(0, ListenerMessage::count());
+    }
+
+    /**
+     * @test
+     * App\Http\Controllers\ListenerMessageController@store
+     */
+    public function ラジオ番組へのメッセージ投稿に失敗する（本文関連）()
+    {
+        $response1 = $this->postJson('api/listener_messages', [
+            'radio_program_id' => $this->radio_program->id,
+            'program_corner_id' => $this->program_corner->id,
+            'listener_id' => $this->listener->id,
+        ]);
+
+        $response1->assertStatus(422)
+            ->assertJsonValidationErrors([
+                'content' => [
+                    '本文を入力してください。'
+                ]
+            ]);
+
+        $response2 = $this->postJson('api/listener_messages', [
+            'radio_program_id' => $this->radio_program->id,
+            'listener_id' => $this->listener->id,
+            'subject' => 'ふつおた',
+        ]);
+
+        $response2->assertStatus(422)
+            ->assertJsonValidationErrors([
+                'content' => [
+                    '本文を入力してください。'
+                ]
+            ]);
+
+        $response3 = $this->postJson('api/listener_messages', [
+            'listener_my_program_id' => $this->listener_my_program->id,
+            'my_program_corner_id' => $this->my_program_corner->id,
+            'listener_id' => $this->listener->id,
+        ]);
+
+        $response3->assertStatus(422)
+            ->assertJsonValidationErrors([
+                'content' => [
+                    '本文を入力してください。'
+                ]
+            ]);
+
+        $response4 = $this->postJson('api/listener_messages', [
+            'listener_my_program_id' => $this->listener_my_program->id,
+            'listener_id' => $this->listener->id,
+            'subject' => 'ふつおた',
+        ]);
+
+        $response4->assertStatus(422)
+            ->assertJsonValidationErrors([
+                'content' => [
+                    '本文を入力してください。'
+                ]
+            ]);
+
+        $this->assertEquals(0, ListenerMessage::count());
+    }
+}


### PR DESCRIPTION
## チケットへのリンク
https://trello.com/c/xfKbeym9/108-%E3%80%90api%E3%80%91%E6%8A%95%E7%A8%BFapi%E5%AE%9F%E8%A3%85-5pt
## やったこと

- メッセージ投稿APIの実装
- メッセージ内容をDBに保存する
- メッセージをラジオ局に送信する

## やらないこと

## できるようになること

- メッセージの投稿

## できなくなること

## 動作確認有無

- PostmanとDev環境にて動作確認済み

## 参考URL

## その他