### PR TITLE
投稿一覧取得APIの実装

### DIFF
--- a/app/DataProviders/Repositories/ListenerRepository.php
+++ b/app/DataProviders/Repositories/ListenerRepository.php
@@ -108,4 +108,15 @@ class ListenerRepository
             'posted_at' => Carbon::now()
         ]);
     }
+
+    /**
+     * リスナーに紐づいた投稿一覧の取得
+     * 
+     * @param int $listener_id リスナーID
+     * @return object 投稿一覧
+     */
+    public function getAllListenerMessages(int $listener_id): object
+    {
+        return $this->listener_message::where('listener_id', $listener_id)->get();
+    }
 }

--- a/app/Http/Controllers/ListenerMessageController.php
+++ b/app/Http/Controllers/ListenerMessageController.php
@@ -18,6 +18,25 @@ class ListenerMessageController extends Controller
     }
 
     /**
+     * リスナーに紐づいた投稿一覧の取得
+     *
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function index()
+    {
+        try {
+            $listener_messages = $this->listener->getAllListenerMessages(auth()->user()->id);
+            return response()->json([
+                'listener_messages' => $listener_messages
+            ], 200, [], JSON_UNESCAPED_UNICODE);
+        } catch (\Throwable $th) {
+            return response()->json([
+                'message' => '投稿一覧の取得に失敗しました。'
+            ], 500, [], JSON_UNESCAPED_UNICODE);
+        }
+    }
+
+    /**
      * メッセージ投稿
      * 
      * @param ListenerMessageRequest $request メッセージ投稿用のリクエストデータ

--- a/app/Services/Listener/ListenerService.php
+++ b/app/Services/Listener/ListenerService.php
@@ -171,4 +171,16 @@ class ListenerService
             $content
         ));
     }
+
+    /**
+     * リスナーに紐づいた投稿一覧の取得
+     * 
+     * @param int $listener_id リスナーID
+     * @return object 投稿一覧
+     */
+    public function getAllListenerMessages(int $listener_id): object
+    {
+        $listener_messages = $this->listener->getAllListenerMessages($listener_id);
+        return $listener_messages;
+    }
 }

--- a/tests/Feature/ListenerMessageTest.php
+++ b/tests/Feature/ListenerMessageTest.php
@@ -338,4 +338,35 @@ class ListenerMessageTest extends TestCase
             'test@example.com',
         ]);
     }
+
+    /**
+     * @test
+     * App\Http\Controllers\ListenerMessageController@index
+     */
+    public function 投稿一覧を取得できる()
+    {
+        Mail::fake();
+        $this->postJson('api/listener_messages', [
+            'radio_program_id' => $this->radio_program->id,
+            'program_corner_id' => $this->program_corner->id,
+            'listener_id' => $this->listener->id,
+            'content' => 'こんにちは。こんばんは。',
+        ]);
+        $this->postJson('api/listener_messages', [
+            'listener_my_program_id' => $this->listener_my_program->id,
+            'listener_id' => $this->listener->id,
+            'subject' => 'ふつおた',
+            'content' => 'こんにちは。',
+            'radio_name' => 'ハイキングベアー'
+        ]);
+
+
+        $response = $this->getJson('api/listener_messages');
+
+        $response->assertStatus(200)
+            ->assertJsonFragment(['content' => 'こんにちは。こんばんは。'])
+            ->assertJsonFragment(['subject' => 'ふつおた'])
+            ->assertJsonFragment(['content' => 'こんにちは。'])
+            ->assertJsonFragment(['radio_name' => 'ハイキングベアー']);
+    }
 }


### PR DESCRIPTION
## チケットへのリンク
https://trello.com/c/C10FyXqH/109-%E3%80%90api%E3%80%91%E6%8A%95%E7%A8%BF%E4%B8%80%E8%A6%A7%E5%8F%96%E5%BE%97api%E5%AE%9F%E8%A3%85-1pt
## やったこと

- 投稿一覧取得APIの実装

## やらないこと

## できるようになること

- 投稿一覧が取得できる

## できなくなること

## 動作確認有無

- ログイン機能実装後Postmanにて動作確認

## 参考URL

## その他