### PR TITLE
投稿個別取得APIの実装

### DIFF
--- a/app/DataProviders/Repositories/ListenerRepository.php
+++ b/app/DataProviders/Repositories/ListenerRepository.php
@@ -119,4 +119,18 @@ class ListenerRepository
     {
         return $this->listener_message::where('listener_id', $listener_id)->get();
     }
+
+    /**
+     * リスナーに紐づいた投稿個別の取得
+     * 
+     * @param int $listener_id リスナーID
+     * @param int $listener_message_id 投稿ID
+     * @return ListenerMessage 投稿データ
+     */
+    public function getSingleListenerMessage(int $listener_id, int $listener_message_id): ListenerMessage
+    {
+        return $this->listener_message::where('id', $listener_message_id)
+            ->where('listener_id', $listener_id)
+            ->first();
+    }
 }

--- a/app/Http/Controllers/ListenerMessageController.php
+++ b/app/Http/Controllers/ListenerMessageController.php
@@ -37,6 +37,26 @@ class ListenerMessageController extends Controller
     }
 
     /**
+     * リスナーに紐づいた投稿個別の取得
+     * 
+     * @param int $listener_message_id 投稿ID
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function show(int $listener_message_id)
+    {
+        try {
+            $listener_message = $this->listener->getSingleListenerMessage(auth()->user()->id, $listener_message_id);
+            return response()->json([
+                'listener_message' => $listener_message
+            ], 200, [], JSON_UNESCAPED_UNICODE);
+        } catch (\Throwable $th) {
+            return response()->json([
+                'message' => '投稿の取得に失敗しました。'
+            ], 500, [], JSON_UNESCAPED_UNICODE);
+        }
+    }
+
+    /**
      * メッセージ投稿
      * 
      * @param ListenerMessageRequest $request メッセージ投稿用のリクエストデータ

--- a/app/Services/Listener/ListenerService.php
+++ b/app/Services/Listener/ListenerService.php
@@ -14,6 +14,7 @@ namespace App\Services\Listener;
 
 use Illuminate\Support\Facades\Mail;
 use App\DataProviders\Models\Listener;
+use App\DataProviders\Models\ListenerMessage;
 use App\DataProviders\Repositories\RadioProgramRepository;
 use App\DataProviders\Repositories\ProgramCornerRepository;
 use App\DataProviders\Repositories\ListenerMyProgramRepository;
@@ -182,5 +183,18 @@ class ListenerService
     {
         $listener_messages = $this->listener->getAllListenerMessages($listener_id);
         return $listener_messages;
+    }
+
+    /**
+     * リスナーに紐づいた投稿個別の取得
+     *
+     * @param int $listener_id リスナーID
+     * @param int $listener_message_id 投稿ID
+     * @return ListenerMessage 投稿データ
+     */
+    public function getSingleListenerMessage(int $listener_id, int $listener_message_id): ListenerMessage
+    {
+        $listener_message = $this->listener->getSingleListenerMessage($listener_id, $listener_message_id);
+        return $listener_message;
     }
 }

--- a/tests/Feature/ListenerMessageTest.php
+++ b/tests/Feature/ListenerMessageTest.php
@@ -369,4 +369,29 @@ class ListenerMessageTest extends TestCase
             ->assertJsonFragment(['content' => 'こんにちは。'])
             ->assertJsonFragment(['radio_name' => 'ハイキングベアー']);
     }
+
+    /**
+     * @test
+     * App\Http\Controllers\ListenerMessageController@show
+     */
+    public function 個別の投稿テンプレートを取得できる()
+    {
+        Mail::fake();
+        $this->postJson('api/listener_messages', [
+            'radio_program_id' => $this->radio_program->id,
+            'listener_id' => $this->listener->id,
+            'subject' => 'ふつおた',
+            'radio_name' => 'ハイキングベアー',
+            'content' => 'こんにちは。こんばんは。',
+        ]);
+        $listener_message = ListenerMessage::first();
+
+
+        $response = $this->getJson('api/listener_messages/' . $listener_message->id);
+
+        $response->assertStatus(200)
+            ->assertJsonFragment(['content' => 'こんにちは。こんばんは。'])
+            ->assertJsonFragment(['subject' => 'ふつおた'])
+            ->assertJsonFragment(['radio_name' => 'ハイキングベアー']);
+    }
 }


### PR DESCRIPTION
## チケットへのリンク
https://trello.com/c/bBpBIHEk/110-%E3%80%90api%E3%80%91%E6%8A%95%E7%A8%BF%E5%80%8B%E5%88%A5%E5%8F%96%E5%BE%97api%E5%AE%9F%E8%A3%85-1pt
## やったこと

- 投稿個別取得APIの実装

## やらないこと

## できるようになること

- 投稿の個別情報を取得できる

## できなくなること

## 動作確認有無

## 参考URL

## その他