### PR TITLE
投稿一時保存APIの実装

### DIFF
--- a/app/DataProviders/Repositories/ListenerRepository.php
+++ b/app/DataProviders/Repositories/ListenerRepository.php
@@ -112,7 +112,7 @@ class ListenerRepository
     /**
      * 投稿メッセージ保存
      * 
-     * @param ListenerMessageRequest $request メッセージ投稿用のリクエストデータ
+     * @param ListenerMessageRequest $request メッセージ保存用のリクエストデータ
      * @param int $listener_id リスナーID
      * @return void
      */

--- a/app/DataProviders/Repositories/ListenerRepository.php
+++ b/app/DataProviders/Repositories/ListenerRepository.php
@@ -110,6 +110,27 @@ class ListenerRepository
     }
 
     /**
+     * 投稿メッセージ保存
+     * 
+     * @param ListenerMessageRequest $request メッセージ投稿用のリクエストデータ
+     * @param int $listener_id リスナーID
+     * @return void
+     */
+    public function saveListenerMyProgram(ListenerMessageRequest $request, int $listener_id)
+    {
+        $this->listener_message::create([
+            'radio_program_id' => $request->radio_program_id ? $request->radio_program_id : null,
+            'program_corner_id' => $request->program_corner_id ? $request->program_corner_id : null,
+            'listener_my_program_id' => $request->listener_my_program_id ? $request->listener_my_program_id : null,
+            'my_program_corner_id' => $request->my_program_corner_id ? $request->my_program_corner_id : null,
+            'listener_id' => $listener_id,
+            'subject' => $request->subject ? $request->subject : null,
+            'content' => $request->content,
+            'radio_name' => $request->radio_name ? $request->radio_name : null,
+        ]);
+    }
+
+    /**
      * リスナーに紐づいた投稿一覧の取得
      * 
      * @param int $listener_id リスナーID

--- a/app/Http/Controllers/ListenerMessageController.php
+++ b/app/Http/Controllers/ListenerMessageController.php
@@ -76,4 +76,24 @@ class ListenerMessageController extends Controller
             ], 409, [], JSON_UNESCAPED_UNICODE);
         }
     }
+
+    /**
+     * メッセージ一時保存
+     * 
+     * @param ListenerMessageRequest $request メッセージ保存用のリクエストデータ
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function save(ListenerMessageRequest $request)
+    {
+        try {
+            $this->listener->saveListenerMyProgram($request, auth()->user()->id);
+            return response()->json([
+                'message' => 'メッセージが保存されました。'
+            ], 201, [], JSON_UNESCAPED_UNICODE);
+        } catch (\Throwable $th) {
+            return response()->json([
+                'message' => 'メッセージの保存に失敗しました。'
+            ], 409, [], JSON_UNESCAPED_UNICODE);
+        }
+    }
 }

--- a/app/Services/Listener/ListenerService.php
+++ b/app/Services/Listener/ListenerService.php
@@ -197,4 +197,17 @@ class ListenerService
         $listener_message = $this->listener->getSingleListenerMessage($listener_id, $listener_message_id);
         return $listener_message;
     }
+
+
+    /**
+     * 投稿メッセージをDBに一時保存
+     * 
+     * @param ListenerMessageRequest $request メッセージ保存用のリクエストデータ
+     * @param int $listener_id リスナーID
+     * @return void
+     */
+    public function saveListenerMyProgram(ListenerMessageRequest $request, int $listener_id)
+    {
+        $this->listener->saveListenerMyProgram($request, $listener_id);
+    }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -33,4 +33,5 @@ Route::group(['middleware' => 'auth:sanctum'], function () {
     Route::apiResource('listener_my_programs', ListenerMyProgramController::class);
     Route::apiResource('my_program_corners', MyProgramCornerController::class);
     Route::apiResource('listener_messages', ListenerMessageController::class);
+    Route::post('/listener_messages/save', [ListenerMessageController::class, 'save']);
 });

--- a/tests/Feature/ListenerMessageTest.php
+++ b/tests/Feature/ListenerMessageTest.php
@@ -394,4 +394,32 @@ class ListenerMessageTest extends TestCase
             ->assertJsonFragment(['subject' => 'ふつおた'])
             ->assertJsonFragment(['radio_name' => 'ハイキングベアー']);
     }
+
+    /**
+     * @test
+     * App\Http\Controllers\ListenerMessageController@save
+     */
+    public function 投稿を保存できる()
+    {
+        $response = $this->postJson('api/listener_messages/save', [
+            'radio_program_id' => $this->radio_program->id,
+            'program_corner_id' => $this->program_corner->id,
+            'listener_id' => $this->listener->id,
+            'content' => 'こんにちは。こんばんは。',
+        ]);
+
+        $response->assertStatus(201)
+            ->assertJson([
+                'message' => 'メッセージが保存されました。'
+            ]);
+
+        $listener_message = ListenerMessage::first();
+        $this->assertEquals($this->radio_program->id, $listener_message->radio_program_id);
+        $this->assertEquals($this->program_corner->id, $listener_message->program_corner_id);
+        $this->assertEquals($this->listener->id, $listener_message->listener_id);
+        $this->assertEquals('こんにちは。こんばんは。', $listener_message->content);
+        $this->assertEquals('テスト番組', $listener_message->RadioProgram->name);
+        $this->assertEquals('死んでもやめんじゃねーぞ', $listener_message->ProgramCorner->name);
+        $this->assertEquals(null, $listener_message->posted_at);
+    }
 }


### PR DESCRIPTION
## チケットへのリンク
https://trello.com/c/v4NBxYCU/111-%E3%80%90api%E3%80%91%E6%8A%95%E7%A8%BF%E4%B8%80%E6%99%82%E4%BF%9D%E5%AD%98api%E5%AE%9F%E8%A3%85-3pt
## やったこと

- 投稿一時保存APIの実装

## やらないこと

## できるようになること

- 投稿を一時保存できる

## できなくなること

## 動作確認有無

- ログイン機能実装後Postmanにて動作確認

## 参考URL

## その他