### PR TITLE
投稿一時保存個別取得APIの実装

### DIFF
--- a/app/DataProviders/Repositories/ListenerRepository.php
+++ b/app/DataProviders/Repositories/ListenerRepository.php
@@ -154,4 +154,17 @@ class ListenerRepository
             ->where('listener_id', $listener_id)
             ->first();
     }
+
+    /**
+     * リスナーに紐づいた一時保存してある投稿一覧の取得
+     * 
+     * @param int $listener_id リスナーID
+     * @return object 投稿一覧
+     */
+    public function getAllListenerSavedMessages(int $listener_id): object
+    {
+        return $this->listener_message::where('listener_id', $listener_id)
+            ->where('posted_at', null)
+            ->get();
+    }
 }

--- a/app/Http/Controllers/ListenerMessageController.php
+++ b/app/Http/Controllers/ListenerMessageController.php
@@ -57,6 +57,25 @@ class ListenerMessageController extends Controller
     }
 
     /**
+     * リスナーに紐づいた一時保存してある投稿一覧の取得
+     *
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function savedMessages()
+    {
+        try {
+            $listener_messages = $this->listener->getAllListenerSavedMessages(auth()->user()->id);
+            return response()->json([
+                'listener_messages' => $listener_messages
+            ], 200, [], JSON_UNESCAPED_UNICODE);
+        } catch (\Throwable $th) {
+            return response()->json([
+                'message' => '投稿一覧の取得に失敗しました。'
+            ], 500, [], JSON_UNESCAPED_UNICODE);
+        }
+    }
+
+    /**
      * メッセージ投稿
      * 
      * @param ListenerMessageRequest $request メッセージ投稿用のリクエストデータ

--- a/app/Services/Listener/ListenerService.php
+++ b/app/Services/Listener/ListenerService.php
@@ -198,6 +198,17 @@ class ListenerService
         return $listener_message;
     }
 
+    /**
+     * リスナーに紐づいた一保存してある投稿一覧の取得
+     * 
+     * @param int $listener_id リスナーID
+     * @return object 投稿一覧
+     */
+    public function getAllListenerSavedMessages(int $listener_id): object
+    {
+        $listener_messages = $this->listener->getAllListenerSavedMessages($listener_id);
+        return $listener_messages;
+    }
 
     /**
      * 投稿メッセージをDBに一時保存

--- a/routes/api.php
+++ b/routes/api.php
@@ -34,5 +34,5 @@ Route::group(['middleware' => 'auth:sanctum'], function () {
     Route::apiResource('my_program_corners', MyProgramCornerController::class);
     Route::apiResource('listener_messages', ListenerMessageController::class);
     Route::post('/listener_messages/save', [ListenerMessageController::class, 'save']);
-    Route::get('/listener_messages/saved_messages', [ListenerMessageController::class, 'savedMessages']);
+    Route::get('/saved_messages', [ListenerMessageController::class, 'savedMessages']);
 });

--- a/routes/api.php
+++ b/routes/api.php
@@ -34,4 +34,5 @@ Route::group(['middleware' => 'auth:sanctum'], function () {
     Route::apiResource('my_program_corners', MyProgramCornerController::class);
     Route::apiResource('listener_messages', ListenerMessageController::class);
     Route::post('/listener_messages/save', [ListenerMessageController::class, 'save']);
+    Route::get('/listener_messages/saved_messages', [ListenerMessageController::class, 'savedMessages']);
 });

--- a/tests/Feature/ListenerMessageTest.php
+++ b/tests/Feature/ListenerMessageTest.php
@@ -422,4 +422,45 @@ class ListenerMessageTest extends TestCase
         $this->assertEquals('死んでもやめんじゃねーぞ', $listener_message->ProgramCorner->name);
         $this->assertEquals(null, $listener_message->posted_at);
     }
+
+
+    /**
+     * @test
+     * App\Http\Controllers\ListenerMessageController@savedMessage
+     */
+    public function 一時保存してある投稿一覧を取得できる()
+    {
+        Mail::fake();
+        $this->postJson('api/listener_messages', [
+            'radio_program_id' => $this->radio_program->id,
+            'program_corner_id' => $this->program_corner->id,
+            'listener_id' => $this->listener->id,
+            'content' => 'こんにちは。こんばんは。',
+        ]);
+        $this->postJson('api/listener_messages/save', [
+            'listener_my_program_id' => $this->listener_my_program->id,
+            'listener_id' => $this->listener->id,
+            'subject' => 'ふつおた1',
+            'content' => 'こんにちは1',
+            'radio_name' => 'ハイキングベアー'
+        ]);
+        $this->postJson('api/listener_messages/save', [
+            'listener_my_program_id' => $this->listener_my_program->id,
+            'listener_id' => $this->listener->id,
+            'subject' => 'ふつおた2',
+            'content' => 'こんにちは2',
+            'radio_name' => 'ハイキングベアー'
+        ]);
+
+
+        $response = $this->getJson('api/saved_messages');
+
+        $response->assertStatus(200)
+            ->assertJsonFragment(['content' => 'こんにちは1'])
+            ->assertJsonFragment(['content' => 'こんにちは2'])
+            ->assertJsonFragment(['subject' => 'ふつおた1'])
+            ->assertJsonFragment(['subject' => 'ふつおた2'])
+            ->assertJsonFragment(['radio_name' => 'ハイキングベアー'])
+            ->assertJsonMissing(['content' => 'こんにちは。こんばんは。']);
+    }
 }


### PR DESCRIPTION
## チケットへのリンク
https://trello.com/c/ceQ80LAR/310-%E3%80%90api%E3%80%91%E6%8A%95%E7%A8%BF%E4%B8%80%E6%99%82%E4%BF%9D%E5%AD%98%E4%B8%80%E8%A6%A7%E5%8F%96%E5%BE%97api%E5%AE%9F%E8%A3%85-1pt
## やったこと

- 投稿一時保存個別取得APIの実装

## やらないこと

## できるようになること

- 一時保存した投稿一覧が取得できるようになる

## できなくなること

## 動作確認有無

## 参考URL

## その他