### PR TITLE
リスナー情報更新APIの実装

### DIFF
--- a/app/DataProviders/Repositories/ListenerRepository.php
+++ b/app/DataProviders/Repositories/ListenerRepository.php
@@ -76,6 +76,19 @@ class ListenerRepository
     }
 
     /**
+     * リスナー更新
+     * 
+     * @param ListenerRequest $request リスナー更新用のリクエストデータ
+     * @param int $listener_id リスナーID
+     * @return void
+     */
+    public function UpdateListener(ListenerRequest $request, int $listener_id): void
+    {
+        $this->listener::where('id', $listener_id)
+            ->update($request->all());
+    }
+
+    /**
      * リスナー情報取得
      * 
      * @param int $listener_id リスナーID

--- a/app/DataProviders/Repositories/ListenerRepository.php
+++ b/app/DataProviders/Repositories/ListenerRepository.php
@@ -17,6 +17,7 @@ use App\DataProviders\Models\ListenerMessage;
 use App\Http\Requests\ListenerRequest;
 use App\Http\Requests\ListenerMessageRequest;
 use Carbon\Carbon;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Hash;
 
 /**
@@ -78,11 +79,11 @@ class ListenerRepository
     /**
      * リスナー更新
      * 
-     * @param ListenerRequest $request リスナー更新用のリクエストデータ
+     * @param \Illuminate\Http\Request $request リスナー更新用のリクエストデータ
      * @param int $listener_id リスナーID
      * @return void
      */
-    public function UpdateListener(ListenerRequest $request, int $listener_id): void
+    public function UpdateListener(Request $request, int $listener_id): void
     {
         $this->listener::where('id', $listener_id)
             ->update($request->all());

--- a/app/Http/Controllers/ListenerController.php
+++ b/app/Http/Controllers/ListenerController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Requests\ListenerRequest;
 use App\Services\Listener\ListenerService;
 
 class ListenerController extends Controller
@@ -31,6 +32,26 @@ class ListenerController extends Controller
         } catch (\Throwable $th) {
             return response()->json([
                 'message' => 'リスナーデータの取得に失敗しました。'
+            ], 500, [], JSON_UNESCAPED_UNICODE);
+        }
+    }
+
+    /**
+     * リスナー情報更新
+     *
+     * @param ListenerRequest $request リスナー登録用のリクエストデータ
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function update(ListenerRequest $request)
+    {
+        try {
+            $this->listener->UpdateListener($request, auth()->user()->id);
+            return response()->json([
+                'message' => 'リスナーデータの更新に成功しました。'
+            ], 200, [], JSON_UNESCAPED_UNICODE);
+        } catch (\Throwable $th) {
+            return response()->json([
+                'message' => 'リスナーデータの更新に失敗しました。'
             ], 500, [], JSON_UNESCAPED_UNICODE);
         }
     }

--- a/app/Http/Controllers/ListenerController.php
+++ b/app/Http/Controllers/ListenerController.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Controllers;
 
-use App\Http\Requests\ListenerRequest;
 use App\Services\Listener\ListenerService;
 use Illuminate\Http\Request;
 
@@ -40,7 +39,7 @@ class ListenerController extends Controller
     /**
      * リスナー情報更新
      *
-     * @param \Illuminate\Http\Request $request リスナー登録用のリクエストデータ
+     * @param \Illuminate\Http\Request $request リスナー更新用のリクエストデータ
      * @return \Illuminate\Http\JsonResponse
      */
     public function update(Request $request)

--- a/app/Http/Controllers/ListenerController.php
+++ b/app/Http/Controllers/ListenerController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Http\Requests\ListenerRequest;
 use App\Services\Listener\ListenerService;
+use Illuminate\Http\Request;
 
 class ListenerController extends Controller
 {
@@ -39,16 +40,16 @@ class ListenerController extends Controller
     /**
      * リスナー情報更新
      *
-     * @param ListenerRequest $request リスナー登録用のリクエストデータ
+     * @param \Illuminate\Http\Request $request リスナー登録用のリクエストデータ
      * @return \Illuminate\Http\JsonResponse
      */
-    public function update(ListenerRequest $request)
+    public function update(Request $request)
     {
         try {
             $this->listener->UpdateListener($request, auth()->user()->id);
             return response()->json([
                 'message' => 'リスナーデータの更新に成功しました。'
-            ], 200, [], JSON_UNESCAPED_UNICODE);
+            ], 201, [], JSON_UNESCAPED_UNICODE);
         } catch (\Throwable $th) {
             return response()->json([
                 'message' => 'リスナーデータの更新に失敗しました。'

--- a/app/Services/Listener/ListenerService.php
+++ b/app/Services/Listener/ListenerService.php
@@ -93,6 +93,19 @@ class ListenerService
     }
 
     /**
+     * リスナー更新
+     * 
+     * @param ListenerRequest $request リスナー更新用のリクエストデータ
+     * @param int $listener_id リスナーID
+     * @return void
+     */
+    public function UpdateListener(ListenerRequest $request, $listener_id): void
+    {
+        $request->offsetUnset('password');
+        $this->listener->UpdateListener($request, $listener_id);
+    }
+
+    /**
      * リスナー情報取得
      *
      * @param int $listener_id リスナーID

--- a/app/Services/Listener/ListenerService.php
+++ b/app/Services/Listener/ListenerService.php
@@ -23,6 +23,7 @@ use App\DataProviders\Repositories\ListenerRepository;
 use App\Http\Requests\ListenerRequest;
 use App\Http\Requests\ListenerMessageRequest;
 use App\Mail\ListenerMessageMail;
+use Illuminate\Http\Request;
 
 /**
  * リスナー用のサービスクラス
@@ -95,11 +96,11 @@ class ListenerService
     /**
      * リスナー更新
      * 
-     * @param ListenerRequest $request リスナー更新用のリクエストデータ
+     * @param \Illuminate\Http\Request $request リスナー更新用のリクエストデータ
      * @param int $listener_id リスナーID
      * @return void
      */
-    public function UpdateListener(ListenerRequest $request, $listener_id): void
+    public function UpdateListener(Request $request, $listener_id): void
     {
         $request->offsetUnset('email');
         $request->offsetUnset('password');

--- a/app/Services/Listener/ListenerService.php
+++ b/app/Services/Listener/ListenerService.php
@@ -101,7 +101,9 @@ class ListenerService
      */
     public function UpdateListener(ListenerRequest $request, $listener_id): void
     {
+        $request->offsetUnset('email');
         $request->offsetUnset('password');
+
         $this->listener->UpdateListener($request, $listener_id);
     }
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -29,6 +29,7 @@ Route::post('/logout', [LoginController::class, 'logout'])->name('logout');
 
 Route::group(['middleware' => 'auth:sanctum'], function () {
     Route::get('/listener', [ListenerController::class, 'show']);
+    Route::put('/listener', [ListenerController::class, 'update']);
     Route::apiResource('radio_stations', RadioStationController::class);
     Route::apiResource('radio_programs', RadioProgramController::class);
     Route::apiResource('program_corners', ProgramCornerController::class);

--- a/tests/Feature/ListenerTest.php
+++ b/tests/Feature/ListenerTest.php
@@ -151,6 +151,42 @@ class ListenerTest extends TestCase
         $this->assertEquals(0, Listener::count());
     }
 
+
+    /**
+     * @test
+     * App\Http\Controllers\Auth\ListenerController@update
+     */
+    public function リスナー情報を更新できる()
+    {
+        $this->postJson('api/register', [
+            'last_name' => 'テスト',
+            'first_name' => '太郎',
+            'last_name_kana' => 'てすと',
+            'first_name_kana' => 'たろう',
+            'radio_name' => 'ハイキングベアー',
+            'post_code' => '1111111',
+            'prefecture' => '東京都',
+            'city' => '新宿区',
+            'house_number' => '00-000000-000000',
+            'tel' => '00-000-0000',
+            'email' => 'test@example.com',
+            'password' => 'password123'
+        ]);
+
+        $listener = Listener::first();
+        $this->assertEquals('テスト', $listener->last_name);
+        $this->assertEquals('太郎', $listener->first_name);
+        $this->assertEquals('てすと', $listener->last_name_kana);
+        $this->assertEquals('たろう', $listener->first_name_kana);
+        $this->assertEquals('ハイキングベアー', $listener->radio_name);
+        $this->assertEquals('1111111', $listener->post_code);
+        $this->assertEquals('東京都', $listener->prefecture);
+        $this->assertEquals('新宿区', $listener->city);
+        $this->assertEquals('00-000000-000000', $listener->house_number);
+        $this->assertEquals('00-000-0000', $listener->tel);
+        $this->assertEquals('test@example.com', $listener->email);
+    }
+
     /**
      * @test
      * App\Http\Controllers\Auth\loginController@login

--- a/tests/Feature/ListenerTest.php
+++ b/tests/Feature/ListenerTest.php
@@ -158,33 +158,24 @@ class ListenerTest extends TestCase
      */
     public function リスナー情報を更新できる()
     {
-        $this->postJson('api/register', [
-            'last_name' => 'テスト',
-            'first_name' => '太郎',
-            'last_name_kana' => 'てすと',
-            'first_name_kana' => 'たろう',
-            'radio_name' => 'ハイキングベアー',
-            'post_code' => '1111111',
+        $listener = $this->loginAsListener();
+
+        $response = $this->putJson('api/listener', [
+            'radio_name' => 'エアーポップ',
             'prefecture' => '東京都',
-            'city' => '新宿区',
-            'house_number' => '00-000000-000000',
-            'tel' => '00-000-0000',
-            'email' => 'test@example.com',
+            'email' => 'testupdate@example.com',
             'password' => 'password123'
         ]);
 
-        $listener = Listener::first();
-        $this->assertEquals('テスト', $listener->last_name);
-        $this->assertEquals('太郎', $listener->first_name);
-        $this->assertEquals('てすと', $listener->last_name_kana);
-        $this->assertEquals('たろう', $listener->first_name_kana);
-        $this->assertEquals('ハイキングベアー', $listener->radio_name);
-        $this->assertEquals('1111111', $listener->post_code);
-        $this->assertEquals('東京都', $listener->prefecture);
-        $this->assertEquals('新宿区', $listener->city);
-        $this->assertEquals('00-000000-000000', $listener->house_number);
-        $this->assertEquals('00-000-0000', $listener->tel);
-        $this->assertEquals('test@example.com', $listener->email);
+        $response->assertStatus(201)
+            ->assertJson([
+                'message' => 'リスナーデータの更新に成功しました。'
+            ]);
+
+        $update_listener = Listener::first();
+        $this->assertEquals('エアーポップ', $update_listener->radio_name);
+        $this->assertEquals('東京都', $update_listener->prefecture);
+        $this->assertEquals($listener->email, $update_listener->email);
     }
 
     /**


### PR DESCRIPTION
## チケットへのリンク
https://trello.com/c/LVMG6pkI/125-%E3%80%90api%E3%80%91%E3%83%A6%E3%83%BC%E3%82%B6%E3%83%BC%E6%83%85%E5%A0%B1%E6%9B%B4%E6%96%B0api%E5%AE%9F%E8%A3%85-1pt
## やったこと

- リスナー情報更新APIの実装

## やらないこと

## できるようになること

- リスナー情報を更新できる

## できなくなること

## 動作確認有無

- フロントとの連携時に動作確認

## 参考URL

## その他