### PR TITLE
リスナー一覧取得APIの実装

### DIFF
--- a/app/DataProviders/Repositories/ListenerRepository.php
+++ b/app/DataProviders/Repositories/ListenerRepository.php
@@ -90,6 +90,16 @@ class ListenerRepository
     }
 
     /**
+     * リスナー一覧取得
+     * 
+     * @return object リスナー一覧データ
+     */
+    public function getAllListeners(): object
+    {
+        return $this->listener::get();
+    }
+
+    /**
      * リスナー情報取得
      * 
      * @param int $listener_id リスナーID

--- a/app/Http/Controllers/ListenerController.php
+++ b/app/Http/Controllers/ListenerController.php
@@ -18,6 +18,25 @@ class ListenerController extends Controller
     }
 
     /**
+     * リスナー一覧取得
+     *
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function index()
+    {
+        try {
+            $listeners = $this->listener->getAllListeners();
+            return response()->json([
+                'listeners' => $listeners
+            ], 200, [], JSON_UNESCAPED_UNICODE);
+        } catch (\Throwable $th) {
+            return response()->json([
+                'message' => 'リスナー一覧の取得に失敗しました。'
+            ], 500, [], JSON_UNESCAPED_UNICODE);
+        }
+    }
+
+    /**
      * リスナー情報取得
      *
      * @return \Illuminate\Http\JsonResponse

--- a/app/Services/Listener/ListenerService.php
+++ b/app/Services/Listener/ListenerService.php
@@ -109,6 +109,17 @@ class ListenerService
     }
 
     /**
+     * リスナー一覧取得
+     *
+     * @return object リスナー一覧 データ
+     */
+    public function getAllListeners(): object
+    {
+        $listeners = $this->listener->getAllListeners();
+        return $listeners;
+    }
+
+    /**
      * リスナー情報取得
      *
      * @param int $listener_id リスナーID

--- a/routes/api.php
+++ b/routes/api.php
@@ -28,6 +28,7 @@ Route::post('/login', [LoginController::class, 'login'])->name('login');
 Route::post('/logout', [LoginController::class, 'logout'])->name('logout');
 
 Route::group(['middleware' => 'auth:sanctum'], function () {
+    Route::get('/listeners', [ListenerController::class, 'index']);
     Route::get('/listener', [ListenerController::class, 'show']);
     Route::put('/listener', [ListenerController::class, 'update']);
     Route::apiResource('radio_stations', RadioStationController::class);

--- a/tests/Feature/ListenerTest.php
+++ b/tests/Feature/ListenerTest.php
@@ -151,7 +151,6 @@ class ListenerTest extends TestCase
         $this->assertEquals(0, Listener::count());
     }
 
-
     /**
      * @test
      * App\Http\Controllers\Auth\ListenerController@update
@@ -302,9 +301,9 @@ class ListenerTest extends TestCase
 
     /**
      * @test
-     * App\Http\Controllers\ListenerController@show
+     * App\Http\Controllers\ListenerController@index
      */
-    public function リスナー情報を取得できる()
+    public function リスナー一覧を取得できる()
     {
         $listener = $this->loginAsListener();
 
@@ -326,5 +325,37 @@ class ListenerTest extends TestCase
                     'email' => $listener->email,
                 ]
             ]);
+    }
+
+    /**
+     * @test
+     * App\Http\Controllers\ListenerController@show
+     */
+    public function リスナー情報を取得できる()
+    {
+        $listener = $this->loginAsListener();
+        $this->postJson('api/register', [
+            'last_name' => 'テスト',
+            'first_name' => '太郎',
+            'last_name_kana' => 'てすと',
+            'first_name_kana' => 'たろう',
+            'radio_name' => 'ハイキングベアー',
+            'post_code' => '1111111',
+            'prefecture' => '東京都',
+            'city' => '新宿区',
+            'house_number' => '00-000000-000000',
+            'tel' => '00-000-0000',
+            'email' => 'test@example.com',
+            'password' => 'password123'
+        ]);
+
+        $response = $this->getJson('api/listeners');
+
+        $response->assertStatus(200)
+            ->assertJsonFragment(['email' => 'test@example.com'])
+            ->assertJsonFragment(['email' => $listener->email])
+            ->assertJsonFragment(['last_name' => 'テスト'])
+            ->assertJsonFragment(['last_name' => $listener->last_name])
+            ->assertJsonFragment(['radio_name' => 'ハイキングベアー']);
     }
 }


### PR DESCRIPTION
## チケットへのリンク
https://trello.com/c/lM9o6UHu/126-%E3%80%90api%E3%80%91%E3%83%AA%E3%82%B9%E3%83%8A%E3%83%BC%E4%B8%80%E8%A6%A7%E5%8F%96%E5%BE%97api%E5%AE%9F%E8%A3%85-1pt
## やったこと

- リスナー一覧取得APIの実装

## やらないこと

## できるようになること

- リスナー一覧を取得できるようになる

## できなくなること

## 動作確認有無

- フロントとの連携後動作確認

## 参考URL

## その他