### PR TITLE
パスワード再設定用メール送信APIの実装

### DIFF
--- a/app/Http/Controllers/Auth/ForgotPasswordController.php
+++ b/app/Http/Controllers/Auth/ForgotPasswordController.php
@@ -4,7 +4,6 @@ namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;
 use App\Http\Requests\ForgotPasswordRequest;
-use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Password;
 
 class ForgotPasswordController extends Controller

--- a/app/Http/Controllers/Auth/ForgotPasswordController.php
+++ b/app/Http/Controllers/Auth/ForgotPasswordController.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Controllers\Auth;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\ForgotPasswordRequest;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Password;
+
+class ForgotPasswordController extends Controller
+{
+    /**
+     * パスワード再設定メール送信
+     * 
+     * @param ForgotPasswordRequest $request パスワード再設定メール送信用リクエスト
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function sendResetLinkEmail(ForgotPasswordRequest $request)
+    {
+
+        $status = Password::sendResetLink(
+            $request->only('email')
+        );
+
+        if ($status === Password::RESET_LINK_SENT) {
+            return response()->json([
+                'messege' => 'パスワード再設定用のメールを送信しました。'
+            ], 200, [], JSON_UNESCAPED_UNICODE);
+        } else {
+            return response()->json([
+                'messege' => 'パスワード再設定用のメールの送信に失敗しました。'
+            ], 500, [], JSON_UNESCAPED_UNICODE);
+        }
+    }
+}

--- a/app/Http/Requests/ForgotPasswordRequest.php
+++ b/app/Http/Requests/ForgotPasswordRequest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Http\Exceptions\HttpResponseException;
+
+class ForgotPasswordRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'email' => 'required|email',
+        ];
+    }
+
+    public function messages()
+    {
+        return [
+            'email.required' => 'メールアドレスを入力してください。',
+            'email.email' => 'メールアドレスは正しい形式で入力してください。',
+        ];
+    }
+
+    protected function failedValidation($validator)
+    {
+        $response = response()->json([
+            'status' => 422,
+            'errors' => $validator->errors(),
+        ], 422);
+
+        throw new HttpResponseException($response);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\Auth\RegisterController;
 use App\Http\Controllers\Auth\LoginController;
+use App\Http\Controllers\Auth\ForgotPasswordController;
 use App\Http\Controllers\ListenerController;
 use App\Http\Controllers\RadioStationController;
 use App\Http\Controllers\RadioProgramController;
@@ -26,7 +27,11 @@ use Illuminate\Support\Facades\Route;
 Route::post('/register', [RegisterController::class, 'create'])->name('register');
 Route::post('/login', [LoginController::class, 'login'])->name('login');
 Route::post('/logout', [LoginController::class, 'logout'])->name('logout');
-
+// TODO: パスワード再設定用の画面は別で設定する
+Route::get('/test', function () {
+    return 'test';
+})->name('password.reset');
+Route::post('/forgot_password', [ForgotPasswordController::class, 'sendResetLinkEmail']);
 Route::group(['middleware' => 'auth:sanctum'], function () {
     Route::get('/listeners', [ListenerController::class, 'index']);
     Route::get('/listener', [ListenerController::class, 'show']);


### PR DESCRIPTION
## チケットへのリンク
https://trello.com/c/xjQd4q5Y/127-%E3%80%90api%E3%80%91%E3%83%91%E3%82%B9%E3%83%AF%E3%83%BC%E3%83%89%E5%86%8D%E7%99%BA%E8%A1%8Capi%E5%AE%9F%E8%A3%85-5pt
## やったこと

- パスワード再設定用メール送信APIの実装

## やらないこと

## できるようになること

- パスワード再設定メールを送れるようになる

## できなくなること

## 動作確認有無

- Postmanにて動作確認済み

## 参考URL

## その他