### PR TITLE
リクエスト機能リスナー投票APIの実装

### DIFF
--- a/app/DataProviders/Models/Listener.php
+++ b/app/DataProviders/Models/Listener.php
@@ -81,4 +81,14 @@ class Listener extends Authenticatable
     {
         return $this->hasMany(RequestFunction::class);
     }
+
+    /**
+     * リスナーリクエスト機能投稿用リレーション
+     * 
+     * @return hasMany
+     */
+    public function RequestFunctionListenerSubmits(): hasMany
+    {
+        return $this->hasMany(RequestFunctionListenerSubmit::class);
+    }
 }

--- a/app/DataProviders/Models/RequestFunctionListenerSubmit.php
+++ b/app/DataProviders/Models/RequestFunctionListenerSubmit.php
@@ -4,10 +4,9 @@ namespace App\DataProviders\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
-class RequestFunction extends Model
+class RequestFunctionListenerSubmit extends Model
 {
     use HasFactory;
 
@@ -18,20 +17,9 @@ class RequestFunction extends Model
      */
     protected $fillable = [
         'listener_id',
-        'name',
-        'detail',
+        'request_function_id',
         'point',
     ];
-
-    /**
-     * リスナーリクエスト機能投稿用リレーション
-     * 
-     * @return HasMany
-     */
-    public function RequestFunctionListenerSubmits(): HasMany
-    {
-        return $this->HasMany(RequestFunctionListenerSubmit::class);
-    }
 
     /**
      * リスナー用リレーション
@@ -41,5 +29,15 @@ class RequestFunction extends Model
     public function listener(): BelongsTo
     {
         return $this->belongsTo(Listener::class);
+    }
+
+    /**
+     * リクエスト機能用リレーション
+     * 
+     * @return BelongsTo
+     */
+    public function RequestFunction(): BelongsTo
+    {
+        return $this->belongsTo(RequestFunction::class);
     }
 }

--- a/app/DataProviders/Repositories/RequestFunctionRepository.php
+++ b/app/DataProviders/Repositories/RequestFunctionRepository.php
@@ -81,9 +81,9 @@ class RequestFunctionRepository
     }
 
     /**
-     * リクエスト機能リスナー投稿
+     * リクエスト機能リスナー投票
      * 
-     * @param RequestFunctionListenerSubmitRequest $request リクエスト機能リスナー投稿用のリクエストデータ
+     * @param RequestFunctionListenerSubmitRequest $request リクエスト機能リスナー投票用のリクエストデータ
      * @param int $listener_id リスナーID
      * @return void
      */
@@ -100,7 +100,7 @@ class RequestFunctionRepository
     }
 
     /**
-     * 投稿した機能かどうか
+     * 投票した機能かどうか
      * 
      * @param int $request_function_id リクエスト機能ID
      * @param int $listener_id リスナーID

--- a/app/DataProviders/Repositories/RequestFunctionRepository.php
+++ b/app/DataProviders/Repositories/RequestFunctionRepository.php
@@ -84,7 +84,7 @@ class RequestFunctionRepository
      * リクエスト機能リスナー投稿
      * 
      * @param RequestFunctionListenerSubmitRequest $request リクエスト機能リスナー投稿用のリクエストデータ
-     * @param int $listener_id リスナーIDx
+     * @param int $listener_id リスナーID
      * @return void
      */
     public function submitListenerPoint(RequestFunctionListenerSubmitRequest $request, int $listener_id)

--- a/app/DataProviders/Repositories/RequestFunctionRepository.php
+++ b/app/DataProviders/Repositories/RequestFunctionRepository.php
@@ -13,7 +13,9 @@
 namespace App\DataProviders\Repositories;
 
 use App\DataProviders\Models\RequestFunction;
+use App\DataProviders\Models\RequestFunctionListenerSubmit;
 use App\Http\Requests\RequestFunctionRequest;
+use App\Http\Requests\RequestFunctionListenerSubmitRequest;
 
 /**
  * リクエスト機能リポジトリクラス
@@ -29,14 +31,20 @@ class RequestFunctionRepository
     private $request_function;
 
     /**
+     * @var RequestFunctionListenerSubmit $request_function_listener_submit RequestFunctionListenerSubmitインスタンス
+     */
+    private $request_function_listener_submit;
+
+    /**
      * コンストラクタ
      *
      * @param RequestFunction $request_function RequestFunctionModel
      * @return void
      */
-    public function __construct(RequestFunction $request_function)
+    public function __construct(RequestFunction $request_function, RequestFunctionListenerSubmit $request_function_listener_submit)
     {
         $this->request_function = $request_function;
+        $this->request_function_listener_submit = $request_function_listener_submit;
     }
 
     /**
@@ -70,5 +78,38 @@ class RequestFunctionRepository
     public function storeRequestFunction(RequestFunctionRequest $request): RequestFunction
     {
         return $this->request_function::create($request->all());
+    }
+
+    /**
+     * リクエスト機能リスナー投稿
+     * 
+     * @param RequestFunctionListenerSubmitRequest $request リクエスト機能リスナー投稿用のリクエストデータ
+     * @param int $listener_id リスナーIDx
+     * @return void
+     */
+    public function submitListenerPoint(RequestFunctionListenerSubmitRequest $request, int $listener_id)
+    {
+        $this->request_function_listener_submit::create([
+            'listener_id' => $listener_id,
+            'request_function_id' => $request->request_function_id,
+            'point' => (int)$request->point
+        ]);
+        $request_function = $this->getSingleRequestFunction($request->request_function_id);
+        $request_function->point = $request_function->point + (int)$request->point;
+        $request_function->save();
+    }
+
+    /**
+     * 投稿した機能かどうか
+     * 
+     * @param int $request_function_id リクエスト機能ID
+     * @param int $listener_id リスナーID
+     * @return bool
+     */
+    public function isSubmittedListener(int $request_function_id, int $listener_id): bool
+    {
+        return $this->request_function_listener_submit::where('request_function_id', $request_function_id)
+            ->where('listener_id', $listener_id)
+            ->exists();
     }
 }

--- a/app/Http/Controllers/RequestFunctionController.php
+++ b/app/Http/Controllers/RequestFunctionController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Services\Listener\RequestFunctionService;
 use App\Http\Requests\RequestFunctionRequest;
+use App\Http\Requests\RequestFunctionListenerSubmitRequest;
 
 class RequestFunctionController extends Controller
 {
@@ -72,6 +73,31 @@ class RequestFunctionController extends Controller
         } catch (\Throwable $th) {
             return response()->json([
                 'message' => 'リクエスト機能の作成に失敗しました。'
+            ], 409, [], JSON_UNESCAPED_UNICODE);
+        }
+    }
+
+    /**
+     * リクエスト機能リスナー投稿
+     * 
+     * @param RequestFunctionListenerSubmitRequest $request リクエスト機能リスナー投稿用のリクエストデータ
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function submitListenerPoint(RequestFunctionListenerSubmitRequest $request)
+    {
+        if ($this->request_function->isSubmittedListener($request->request_function_id, auth()->user()->id)) {
+            return response()->json([
+                'message' => 'この機能には既に投稿してあります。'
+            ], 409, [], JSON_UNESCAPED_UNICODE);
+        };
+        try {
+            $this->request_function->submitListenerPoint($request, auth()->user()->id);
+            return response()->json([
+                'message' => '投票が完了しました。'
+            ], 201, [], JSON_UNESCAPED_UNICODE);
+        } catch (\Throwable $th) {
+            return response()->json([
+                'message' => '投票に失敗しました。'
             ], 409, [], JSON_UNESCAPED_UNICODE);
         }
     }

--- a/app/Http/Controllers/RequestFunctionController.php
+++ b/app/Http/Controllers/RequestFunctionController.php
@@ -78,16 +78,16 @@ class RequestFunctionController extends Controller
     }
 
     /**
-     * リクエスト機能リスナー投稿
+     * リクエスト機能リスナー投票
      * 
-     * @param RequestFunctionListenerSubmitRequest $request リクエスト機能リスナー投稿用のリクエストデータ
+     * @param RequestFunctionListenerSubmitRequest $request リクエスト機能リスナー投票用のリクエストデータ
      * @return \Illuminate\Http\JsonResponse
      */
     public function submitListenerPoint(RequestFunctionListenerSubmitRequest $request)
     {
         if ($this->request_function->isSubmittedListener($request->request_function_id, auth()->user()->id)) {
             return response()->json([
-                'message' => 'この機能には既に投稿してあります。'
+                'message' => 'この機能には既に投票してあります。'
             ], 409, [], JSON_UNESCAPED_UNICODE);
         };
         try {

--- a/app/Http/Requests/RequestFunctionListenerSubmitRequest.php
+++ b/app/Http/Requests/RequestFunctionListenerSubmitRequest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Http\Exceptions\HttpResponseException;
+
+class RequestFunctionListenerSubmitRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'request_function_id' => 'required',
+            'point' => 'required',
+        ];
+    }
+
+    public function messages()
+    {
+        return [
+            'point.required' => 'ポイントを入力してください。',
+        ];
+    }
+
+    protected function failedValidation($validator)
+    {
+        $response = response()->json([
+            'status' => 422,
+            'errors' => $validator->errors(),
+        ], 422);
+
+        throw new HttpResponseException($response);
+    }
+}

--- a/app/Services/Listener/RequestFunctionService.php
+++ b/app/Services/Listener/RequestFunctionService.php
@@ -76,9 +76,9 @@ class RequestFunctionService
     }
 
     /**
-     * リクエスト機能リスナー投稿
+     * リクエスト機能リスナー投票
      * 
-     * @param RequestFunctionListenerSubmitRequest $request リクエスト機能リスナー投稿用のリクエストデータ
+     * @param RequestFunctionListenerSubmitRequest $request リクエスト機能リスナー投票用のリクエストデータ
      * @param int $listener_id リスナーIDx
      * @return void
      */
@@ -88,7 +88,7 @@ class RequestFunctionService
     }
 
     /**
-     * 投稿した機能かどうか
+     * 投票した機能かどうか
      * 
      * @param int $request_function_id リクエスト機能ID
      * @param int $listener_id リスナーID

--- a/app/Services/Listener/RequestFunctionService.php
+++ b/app/Services/Listener/RequestFunctionService.php
@@ -15,6 +15,7 @@ namespace App\Services\Listener;
 use App\DataProviders\Models\RequestFunction;
 use App\DataProviders\Repositories\RequestFunctionRepository;
 use App\Http\Requests\RequestFunctionRequest;
+use App\Http\Requests\RequestFunctionListenerSubmitRequest;
 
 /**
  * リクエスト機能用のサービスクラス
@@ -72,5 +73,29 @@ class RequestFunctionService
     {
         $request_function = $this->request_function->storeRequestFunction($request);
         return $request_function;
+    }
+
+    /**
+     * リクエスト機能リスナー投稿
+     * 
+     * @param RequestFunctionListenerSubmitRequest $request リクエスト機能リスナー投稿用のリクエストデータ
+     * @param int $listener_id リスナーIDx
+     * @return void
+     */
+    public function submitListenerPoint(RequestFunctionListenerSubmitRequest $request, int $listener_id)
+    {
+        $this->request_function->submitListenerPoint($request, $listener_id);
+    }
+
+    /**
+     * 投稿した機能かどうか
+     * 
+     * @param int $request_function_id リクエスト機能ID
+     * @param int $listener_id リスナーID
+     * @return bool
+     */
+    public function isSubmittedListener(int $request_function_id, int $listener_id): bool
+    {
+        return $this->request_function->isSubmittedListener($request_function_id, $listener_id);
     }
 }

--- a/database/migrations/2022_04_25_223727_create_request_function_listener_submits_table.php
+++ b/database/migrations/2022_04_25_223727_create_request_function_listener_submits_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('request_function_listener_submits', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('listener_id')->nullOnDelete('cascade')->constrained('listeners');
+            $table->foreignId('request_function_id')->nullOnDelete('cascade')->constrained('request_functions');
+            $table->integer('point');
+            $table->unique(['listener_id', 'request_function_id'], 'request_function_listener_id');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('request_function_listener_submits');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -47,4 +47,5 @@ Route::group(['middleware' => 'auth:sanctum'], function () {
     Route::post('/listener_messages/save', [ListenerMessageController::class, 'save']);
     Route::get('/saved_messages', [ListenerMessageController::class, 'savedMessages']);
     Route::apiResource('request_functions', RequestFunctionController::class);
+    Route::post('/request_functions/submit_point', [RequestFunctionController::class, 'submitListenerPoint']);
 });


### PR DESCRIPTION
## チケットへのリンク
https://trello.com/c/zU0E9XpX/133-%E3%80%90api%E3%80%91%E6%A9%9F%E8%83%BD%E3%83%AA%E3%82%AF%E3%82%A8%E3%82%B9%E3%83%88%E3%83%9D%E3%82%A4%E3%83%B3%E3%83%88%E6%8A%95%E7%A8%BFapi%E5%AE%9F%E8%A3%85-3pt
## やったこと

- リクエスト機能リスナー投票APIの実装

## やらないこと

## できるようになること

- リスナーがリクエスト機能に投票できるようになる

## できなくなること

## 動作確認有無

- フロントと連携後動作確認

## 参考URL

## その他