### PR TITLE
リクエスト機能削除APIの実装

### DIFF
--- a/app/DataProviders/Repositories/RequestFunctionRepository.php
+++ b/app/DataProviders/Repositories/RequestFunctionRepository.php
@@ -131,4 +131,19 @@ class RequestFunctionRepository
             ->where('listener_id', $listener_id)
             ->exists();
     }
+
+    /**
+     * リクエスト機能削除
+     *
+     * @param int $listener_id リスナーID
+     * @param int $request_function_id リクエスト機能ID
+     * @return bool 削除できたかどうか
+     */
+    public function deleteRequestFunction(int $listener_id, int $request_function_id): bool
+    {
+        $request_function = $this->request_function::where('id', $request_function_id)
+            ->where('listener_id', $listener_id)
+            ->first();
+        return $request_function->delete();
+    }
 }

--- a/app/Http/Controllers/RequestFunctionController.php
+++ b/app/Http/Controllers/RequestFunctionController.php
@@ -123,4 +123,24 @@ class RequestFunctionController extends Controller
             ], 409, [], JSON_UNESCAPED_UNICODE);
         }
     }
+
+    /**
+     * リクエスト機能削除（1つのみ）
+     *
+     * @param int $request_function_id リクエスト機能ID
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function destroy(int $request_function_id)
+    {
+        try {
+            $this->request_function->deleteRequestFunction(auth()->user()->id, $request_function_id);
+            return response()->json([
+                'message' => 'リクエスト機能が削除されました。'
+            ], 200, [], JSON_UNESCAPED_UNICODE);
+        } catch (\Throwable $th) {
+            return response()->json([
+                'message' => 'リクエスト機能の削除に失敗しました。'
+            ], 500, [], JSON_UNESCAPED_UNICODE);
+        }
+    }
 }

--- a/app/Services/Listener/RequestFunctionService.php
+++ b/app/Services/Listener/RequestFunctionService.php
@@ -112,4 +112,17 @@ class RequestFunctionService
     {
         return $this->request_function->isSubmittedListener($request_function_id, $listener_id);
     }
+
+    /**
+     * リクエスト機能削除
+     *
+     * @param int $listener_id リスナーID
+     * @param int $request_function_id  リクエスト機能ID
+     * @return bool 削除できたかどうか
+     */
+    public function deleteRequestFunction(int $listener_id, int $request_function_id): bool
+    {
+        $is_deleted = $this->request_function->deleteRequestFunction($listener_id, $request_function_id);
+        return $is_deleted;
+    }
 }

--- a/tests/Feature/RequestFunctionTest.php
+++ b/tests/Feature/RequestFunctionTest.php
@@ -259,4 +259,23 @@ class RequestFunctionTest extends TestCase
         $request_function = RequestFunction::first();
         $this->assertEquals(3, $request_function->point);
     }
+
+    /**
+     * @test
+     * App\Http\Controllers\RequestFunctionController@destory
+     */
+    public function リクエスト機能を削除できる()
+    {
+        $this->postJson('api/request_functions', ['name' => 'テスト機能1', 'detail' => str_repeat('いい機能ですね', 100), 'listener_id' => $this->listener->id]);
+        $request_function = RequestFunction::first();
+
+        $response = $this->deleteJson('api/request_functions/' . $request_function->id);
+
+        $response->assertStatus(200)
+            ->assertJson([
+                'message' => 'リクエスト機能が削除されました。'
+            ]);
+
+        $this->assertEquals(0, RequestFunction::count());
+    }
 }


### PR DESCRIPTION
## チケットへのリンク
https://trello.com/c/t9PGsDbi/135-%E3%80%90api%E3%80%91%E6%A9%9F%E8%83%BD%E3%83%AA%E3%82%AF%E3%82%A8%E3%82%B9%E3%83%88%E5%89%8A%E9%99%A4api%E5%AE%9F%E8%A3%85-1pt
## やったこと

- リクエスト機能削除APIの実装

## やらないこと

## できるようになること

- リクエスト機能を削除できる

## できなくなること

## 動作確認有無

- フロント連携後動作確認

## 参考URL

## その他