### PR TITLE
パスワード更新APIの実装

### DIFF
--- a/app/Http/Controllers/Auth/PasswordResetController.php
+++ b/app/Http/Controllers/Auth/PasswordResetController.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Http\Controllers\Auth;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\PasswordResetRequest;
+use Illuminate\Support\Facades\Password;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Auth\Events\PasswordReset;
+
+class PasswordResetController extends Controller
+{
+    /**
+     * パスワードリセット
+     * 
+     * @param PasswordResetRequest $request パスワードリセット用パラメータ
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function resetPassword(PasswordResetRequest $request)
+    {
+        $credentials = [
+            'email' => $request->email,
+            'password' => $request->password,
+            'token' => $request->token
+        ];
+
+        $status = Password::reset(
+            $credentials,
+            function ($user, $password) {
+                $user->forceFill([
+                    'password' => Hash::make($password)
+                ]);
+                $user->save();
+                event(new PasswordReset($user));
+            }
+        );
+
+        if ($status === Password::PASSWORD_RESET) {
+            return response()->json([
+                'messege' => 'パスワード変更に成功しました。'
+            ], 200, [], JSON_UNESCAPED_UNICODE);
+        } else {
+            return response()->json([
+                'messege' => 'パスワード変更に失敗しました。'
+            ], 500, [], JSON_UNESCAPED_UNICODE);
+        }
+    }
+}

--- a/app/Http/Requests/PasswordResetRequest.php
+++ b/app/Http/Requests/PasswordResetRequest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Http\Exceptions\HttpResponseException;
+
+class PasswordResetRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return false;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'email' => 'required|email',
+            'password' => 'required|confirmed',
+            'token' => 'required'
+        ];
+    }
+
+    public function messages()
+    {
+        return [
+            'email.required' => 'メールアドレスを入力してください。',
+            'email.email' => 'メールアドレスは正しい形式で入力してください。',
+            'password.required' => 'パスワードを入力してください。',
+            'password.confirmed' => 'パスワードが確認用と異なっています。',
+        ];
+    }
+
+    protected function failedValidation($validator)
+    {
+        $response = response()->json([
+            'status' => 422,
+            'errors' => $validator->errors(),
+        ], 422);
+
+        throw new HttpResponseException($response);
+    }
+}

--- a/app/Http/Requests/PasswordResetRequest.php
+++ b/app/Http/Requests/PasswordResetRequest.php
@@ -14,7 +14,7 @@ class PasswordResetRequest extends FormRequest
      */
     public function authorize()
     {
-        return false;
+        return true;
     }
 
     /**

--- a/routes/api.php
+++ b/routes/api.php
@@ -3,6 +3,7 @@
 use App\Http\Controllers\Auth\RegisterController;
 use App\Http\Controllers\Auth\LoginController;
 use App\Http\Controllers\Auth\ForgotPasswordController;
+use App\Http\Controllers\Auth\PasswordResetController;
 use App\Http\Controllers\ListenerController;
 use App\Http\Controllers\RadioStationController;
 use App\Http\Controllers\RadioProgramController;
@@ -33,6 +34,7 @@ Route::get('/test', function () {
     return 'test';
 })->name('password.reset');
 Route::post('/forgot_password', [ForgotPasswordController::class, 'sendResetLinkEmail']);
+Route::post('password/reset/{token}', [PasswordResetController::class, 'resetPassword']);
 Route::group(['middleware' => 'auth:sanctum'], function () {
     Route::get('/listeners', [ListenerController::class, 'index']);
     Route::get('/listener', [ListenerController::class, 'show']);


### PR DESCRIPTION
## チケットへのリンク
https://trello.com/c/kVzYD50Z/128-%E3%80%90api%E3%80%91%E3%83%91%E3%82%B9%E3%83%AF%E3%83%BC%E3%83%89%E6%9B%B4%E6%96%B0api%E5%AE%9F%E8%A3%85-5pt
## やったこと

- パスワード更新APIの実装

## やらないこと

## できるようになること

- パスワードの更新

## できなくなること

## 動作確認有無

- フロント連携後動作確認

## 参考URL

## その他