### PR TITLE
投稿テンプレート作成のリスナーIDの渡し方修正

### DIFF
--- a/app/DataProviders/Repositories/MessageTemplateRepository.php
+++ b/app/DataProviders/Repositories/MessageTemplateRepository.php
@@ -68,11 +68,18 @@ class MessageTemplateRepository
      * 投稿テンプレート作成
      *
      * @param MessageTemplateRequest $request 投稿テンプレート作成リクエストデータ
+     * @param int $listener_id リスナーID
      * @return MessageTemplate 投稿テンプレート生成データ
      */
-    public function storeMessageTemplate(MessageTemplateRequest $request): MessageTemplate
+    public function storeMessageTemplate(MessageTemplateRequest $request, int $listener_id): MessageTemplate
     {
-        return $this->message_template::create($request->all());
+        return $this->message_template::create(
+            [
+                'name' => $request->name,
+                'content' => $request->content,
+                'listener_id' => $listener_id
+            ]
+        );
     }
 
     /**

--- a/app/Http/Controllers/MessageTemplateController.php
+++ b/app/Http/Controllers/MessageTemplateController.php
@@ -66,8 +66,7 @@ class MessageTemplateController extends Controller
     public function store(MessageTemplateRequest $request)
     {
         try {
-            // TODO: リスナーIDの渡し方検討
-            $this->message_template->storeMessageTemplate($request);
+            $this->message_template->storeMessageTemplate($request, auth()->user()->id);
             return response()->json([
                 'message' => '投稿テンプレートが作成されました。'
             ], 201, [], JSON_UNESCAPED_UNICODE);

--- a/app/Http/Requests/MessageTemplateRequest.php
+++ b/app/Http/Requests/MessageTemplateRequest.php
@@ -27,7 +27,6 @@ class MessageTemplateRequest extends FormRequest
         return [
             'name' => 'required|max: 150',
             'content' => 'required|max: 1000',
-            'listener_id' => 'required'
         ];
     }
 

--- a/app/Services/Listener/MessageTemplateService.php
+++ b/app/Services/Listener/MessageTemplateService.php
@@ -68,11 +68,12 @@ class MessageTemplateService
      * 投稿テンプレート作成
      * 
      * @param MessageTemplateRequest $request 投稿テンプレート登録用のリクエストデータ
+     * @param int $listener_id リスナーID
      * @return MessageTemplate 作成された投稿テンプレート情報
      */
-    public function storeMessageTemplate(MessageTemplateRequest $request): MessageTemplate
+    public function storeMessageTemplate(MessageTemplateRequest $request, int $listener_id): MessageTemplate
     {
-        $message_template = $this->message_template->storeMessageTemplate($request);
+        $message_template = $this->message_template->storeMessageTemplate($request, $listener_id);
         return $message_template;
     }
 


### PR DESCRIPTION
## チケットへのリンク
https://trello.com/c/LSpGFBph/318-%E3%83%A1%E3%83%83%E3%82%BB%E3%83%BC%E3%82%B8%E3%83%86%E3%83%B3%E3%83%97%E3%83%AC%E3%83%BC%E3%83%88%E3%81%AEstore%E3%83%A1%E3%82%BD%E3%83%83%E3%83%89%E3%81%AE%E3%83%AA%E3%82%B9%E3%83%8A%E3%83%BCid%E3%81%AE%E5%A4%89%E6%9B%B4-3pt
## やったこと

- メッセージテンプレートのstoreメソッドのリスナーIDの渡し方変更

## やらないこと

## できるようになること

- なし

## できなくなること

## 動作確認有無

- 自動テスト実行

## 参考URL

## その他