### PR TITLE
投稿メッセージにプレーンテキストメールを追加

### DIFF
--- a/app/Mail/ListenerMessageMail.php
+++ b/app/Mail/ListenerMessageMail.php
@@ -134,6 +134,7 @@ class ListenerMessageMail extends Mailable
         return $this->from(config('mail.from.address'))
             ->subject($this->corner)
             ->view('email.listener_message')
+            ->text('email.listener_message_plain')
             ->with([
                 'full_name' => $this->full_name,
                 'full_name_kana' => $this->full_name_kana,

--- a/resources/views/email/listener_message_plain.blade.php
+++ b/resources/views/email/listener_message_plain.blade.php
@@ -1,0 +1,11 @@
+{{ $prefecture }}
+RN: {{ $radio_name }}
+
+{{ $content }}
+
+----------------------------------------------------------------
+〒{{ $post_code }}
+住所:{{ $prefecture }}　{{ $city }}　{{ $house_number }}　{{ $building }}　{{ $room_number }}
+本名:{{ $full_name}}（{{ $full_name_kana}}）
+電話番号:{{ $tel }}
+メールアドレス:{{ $email }}


### PR DESCRIPTION
## チケットへのリンク
https://trello.com/c/0OpLlW7f/309-plainmail%E3%81%AE%E8%A8%AD%E5%AE%9A-5pt
## やったこと

- 投稿メッセージにプレーンテキストメールを追加

## やらないこと

## できるようになること

-投稿メッセージをプレーンテキストメールで送れるようになる

## できなくなること

## 動作確認有無

- Postmanで動作確認済み

## 参考URL

## その他